### PR TITLE
Add a review adherence audit surface

### DIFF
--- a/src/lib/features/review/Page.svelte
+++ b/src/lib/features/review/Page.svelte
@@ -12,6 +12,7 @@
     setReviewExperiment,
   } from '$lib/features/review/client';
   import {
+    createReviewAdherenceAuditItems,
     createReviewAdherenceCards,
     createNutritionStrategyCards,
     createReviewSections,
@@ -25,6 +26,7 @@
   let reviewSections = $derived(createReviewSections(page.weekly));
   let nutritionStrategyCards = $derived(createNutritionStrategyCards(page.weekly));
   let adherenceCards = $derived(createReviewAdherenceCards(page.weekly));
+  let adherenceAuditItems = $derived(createReviewAdherenceAuditItems(page.weekly));
 
   async function loadWeekly() {
     page = await loadReviewPage();
@@ -58,7 +60,7 @@
       }}
     />
 
-    <ReviewAdherenceSection {adherenceCards} />
+    <ReviewAdherenceSection {adherenceCards} auditItems={adherenceAuditItems} />
 
     <ReviewCorrelationSection correlations={page.weekly.snapshot.correlations} />
 

--- a/src/lib/features/review/analytics-shared.ts
+++ b/src/lib/features/review/analytics-shared.ts
@@ -1,4 +1,9 @@
-import type { DailyRecord, FoodEntry, ReviewSnapshot } from '$lib/core/domain/types';
+import type {
+  AdherenceMatch,
+  DailyRecord,
+  FoodEntry,
+  ReviewSnapshot,
+} from '$lib/core/domain/types';
 import { startOfWeek } from '$lib/core/shared/dates';
 
 export interface ReviewCorrelation {
@@ -37,6 +42,7 @@ export interface WeeklyReviewData {
   planningHighlights: string[];
   adherenceScores: ReviewAdherenceScore[];
   adherenceSignals: string[];
+  adherenceMatches: AdherenceMatch[];
   grocerySignals: string[];
   deviceHighlights: string[];
   assessmentSummary: string[];

--- a/src/lib/features/review/components/ReviewAdherenceSection.svelte
+++ b/src/lib/features/review/components/ReviewAdherenceSection.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { SectionCard } from '$lib/core/ui/primitives';
-  import type { ReviewAdherenceCard } from '$lib/features/review/model';
+  import type { ReviewAdherenceAuditItem, ReviewAdherenceCard } from '$lib/features/review/model';
 
   let {
     adherenceCards,
+    auditItems,
   }: {
     adherenceCards: ReviewAdherenceCard[];
+    auditItems: ReviewAdherenceAuditItem[];
   } = $props();
 </script>
 
@@ -22,6 +24,18 @@
     </div>
   {:else}
     <p class="status-copy">Build a weekly plan before Review can score actual adherence.</p>
+  {/if}
+
+  {#if auditItems.length}
+    <div class="review-adherence-audit">
+      {#each auditItems as item (`${item.badge}-${item.title}-${item.detail}`)}
+        <article class={`review-adherence-audit-item review-adherence-audit-item--${item.tone}`}>
+          <span class="review-adherence-audit-badge">{item.badge}</span>
+          <strong>{item.title}</strong>
+          <p>{item.detail}</p>
+        </article>
+      {/each}
+    </div>
   {/if}
 </SectionCard>
 
@@ -86,5 +100,47 @@
     .review-adherence-cards {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
+  }
+
+  .review-adherence-audit {
+    display: grid;
+    gap: 0.75rem;
+    margin-top: 1rem;
+  }
+
+  .review-adherence-audit-item {
+    display: grid;
+    gap: 0.25rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid rgba(58, 53, 46, 0.08);
+  }
+
+  .review-adherence-audit-item p {
+    margin: 0;
+    color: #3a352e;
+  }
+
+  .review-adherence-audit-badge {
+    width: fit-content;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    font:
+      700 0.72rem/1 Manrope,
+      system-ui,
+      sans-serif;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: rgba(31, 92, 74, 0.08);
+    color: #1f5c4a;
+  }
+
+  .review-adherence-audit-item--attention .review-adherence-audit-badge {
+    background: rgba(148, 59, 47, 0.08);
+    color: #943b2f;
+  }
+
+  .review-adherence-audit-item--mixed .review-adherence-audit-badge {
+    background: rgba(151, 94, 32, 0.08);
+    color: #975e20;
   }
 </style>

--- a/src/lib/features/review/model.ts
+++ b/src/lib/features/review/model.ts
@@ -27,6 +27,13 @@ export type ReviewAdherenceCard = {
   tone: 'steady' | 'mixed' | 'attention';
 };
 
+export type ReviewAdherenceAuditItem = {
+  badge: 'Explicit' | 'Inferred';
+  title: string;
+  detail: string;
+  tone: 'steady' | 'mixed' | 'attention';
+};
+
 function normalizeStrategyDetail(detail: string): string {
   const trimmed = detail.trim();
   return trimmed.endsWith('.') ? trimmed : `${trimmed}.`;
@@ -83,6 +90,41 @@ export function createReviewAdherenceCards(weekly: WeeklyReviewData | null): Rev
         detail: normalizeStrategyDetail(score.detail),
         tone: score.tone,
       }))
+    : [];
+}
+
+function toneForOutcome(
+  outcome: WeeklyReviewData['adherenceMatches'][number]['outcome']
+): ReviewAdherenceAuditItem['tone'] {
+  if (outcome === 'hit') return 'steady';
+  if (outcome === 'miss') return 'attention';
+  return 'mixed';
+}
+
+export function createReviewAdherenceAuditItems(
+  weekly: WeeklyReviewData | null
+): ReviewAdherenceAuditItem[] {
+  return weekly
+    ? weekly.adherenceMatches
+        .filter((match) => match.outcome !== 'pending')
+        .map((match) => {
+          const badge: ReviewAdherenceAuditItem['badge'] =
+            match.confidence === 'explicit' ? 'Explicit' : 'Inferred';
+
+          return {
+            badge,
+            title: match.slotTitle,
+            detail:
+              (match.slotType === 'meal'
+                ? 'Meal'
+                : match.slotType === 'workout'
+                  ? 'Workout'
+                  : 'Note') +
+              `${match.confidence === 'inferred' ? ' inferred' : ''} ${match.outcome}: ${match.reason}`,
+            tone: toneForOutcome(match.outcome),
+          };
+        })
+        .slice(0, 6)
     : [];
 }
 

--- a/src/lib/features/review/service.ts
+++ b/src/lib/features/review/service.ts
@@ -129,6 +129,7 @@ export async function buildWeeklySnapshot(
     planningHighlights: buildPlanningHighlights(weeklyPlan, weekPlanSlots, weekGroceries),
     adherenceScores: buildAdherenceScores(adherenceMatches),
     adherenceSignals: buildAdherenceSignals(adherenceMatches),
+    adherenceMatches,
     grocerySignals: buildGrocerySignals(weekPlanSlots, weekGroceries, anchorDay),
     deviceHighlights: buildDeviceHighlights(weekHealthEvents),
     assessmentSummary: buildAssessmentSummary(weekAssessments),

--- a/tests/features/component/review/ReviewPage.spec.ts
+++ b/tests/features/component/review/ReviewPage.spec.ts
@@ -117,9 +117,11 @@ describe('Review route', () => {
     await waitFor(() => {
       expect(screen.getAllByText(/1 hit, 0 misses, 1 inferred\./i).length).toBeGreaterThan(0);
     });
-    await waitForText(
-      /Meal inferred hit: Greek yogurt bowl matched a logged meal on 2026-04-02\./i
-    );
+    await waitForText('Inferred');
+    await waitFor(() => {
+      expect(screen.getAllByText('Greek yogurt bowl').length).toBeGreaterThan(0);
+    });
+    await waitForText(/Meal inferred hit: matched a logged meal on 2026-04-02\./i);
   });
 
   it('shows actual misses and grocery waste when a planned meal slips', async () => {

--- a/tests/features/unit/review/model.test.ts
+++ b/tests/features/unit/review/model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { WeeklyReviewData } from '$lib/features/review/service';
 import {
+  createReviewAdherenceAuditItems,
   createReviewAdherenceCards,
   createNutritionStrategyCards,
   createReviewSections,
@@ -69,6 +70,24 @@ describe('review model', () => {
         'Meal miss: Teriyaki Chicken Casserole was skipped.',
         'Workout hit: Full body reset was completed as planned.',
       ],
+      adherenceMatches: [
+        {
+          id: 'adherence-1',
+          createdAt: '2026-04-02T08:00:00.000Z',
+          updatedAt: '2026-04-02T08:00:00.000Z',
+          weekStart: '2026-03-31',
+          planSlotId: 'slot-1',
+          localDay: '2026-04-02',
+          slotType: 'meal',
+          slotTitle: 'Greek yogurt bowl',
+          outcome: 'hit',
+          matchSource: 'food-entry',
+          matchedRecordId: 'food-1',
+          confidence: 'inferred',
+          reason: 'matched a logged meal on 2026-04-02.',
+          fingerprint: 'fp-1',
+        },
+      ],
       grocerySignals: [
         'Potential waste: Teriyaki Chicken Casserole was missed after 1 grocery item had already been sourced.',
       ],
@@ -101,6 +120,14 @@ describe('review model', () => {
         label: 'Workouts',
         value: '100%',
         detail: '1 hit, 0 misses.',
+        tone: 'steady',
+      },
+    ]);
+    expect(createReviewAdherenceAuditItems(weekly)).toEqual([
+      {
+        badge: 'Inferred',
+        title: 'Greek yogurt bowl',
+        detail: 'Meal inferred hit: matched a logged meal on 2026-04-02.',
         tone: 'steady',
       },
     ]);
@@ -144,6 +171,7 @@ describe('review model', () => {
       planningHighlights: [],
       adherenceScores: [],
       adherenceSignals: [],
+      adherenceMatches: [],
       grocerySignals: [],
       deviceHighlights: [],
       assessmentSummary: [],


### PR DESCRIPTION
## Summary
- add an adherence audit surface under the existing Review adherence section
- surface inferred vs explicit adherence more clearly without adding a separate page
- keep the change scoped to review UI/model files only

## Verification
- \
 RUN  v4.1.2 /home/pyro1121/Documents/Health


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  21:08:38
   Duration  593ms (transform 284ms, setup 435ms, import 23ms, tests 8ms, environment 0ms)
- \
 RUN  v4.1.2 /home/pyro1121/Documents/Health


 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  21:08:39
   Duration  2.45s (transform 947ms, setup 633ms, import 686ms, tests 487ms, environment 525ms)
- \Loading svelte-check in workspace: /home/pyro1121/Documents/Health
Getting Svelte diagnostics...

svelte-check found 0 errors and 0 warnings

## Summary by Sourcery

Add an adherence audit list to the Review page to surface explicit vs inferred adherence outcomes alongside existing adherence cards.

New Features:
- Display a review adherence audit list under the Review adherence section, showing badge, title, detail, and tone for each outcome.
- Derive adherence audit items from weekly adherence matches, including confidence, outcome, and slot metadata, and limit the list to recent non-pending items.

Enhancements:
- Extend weekly review data and snapshot building to include adherence matches for use by the adherence audit UI.

Tests:
- Expand unit and component tests to cover adherence matches in weekly data and the new adherence audit rendering in the Review page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a review adherence audit list under the Review adherence section to clearly show explicit vs inferred hits and misses with badges, titles, tone, and short details. Extends weekly data with `adherenceMatches` and wires it into the UI; also adds CI hygiene/security checks and updates tests.

- **New Features**
  - Added adherence audit list with "Explicit"/"Inferred" badges, tone, and short details; shows up to 6 non-pending items.
  - Wired from `adherenceMatches` via `createReviewAdherenceAuditItems`; updated `ReviewAdherenceSection.svelte` and `Page.svelte`.
  - Extended weekly types and `buildWeeklySnapshot` to include `adherenceMatches`; added unit/component tests.
  - CI/tooling: added `danger`, `dangerfile.ts`, and workflows `danger.yml`, `reviewdog.yml`, `snyk.yml`; bumped `actions/checkout@v4` and `github/codeql-action@v4`; refreshed `bun.lock`.

- **Bug Fixes**
  - Updated the planned meal locator in E2E tests to target the "Planned next meal" section to avoid ambiguous matches.

<sup>Written for commit 085c7c4ba16b5cf4df7f50ca78969ca9543f9d17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

