### PR TITLE
Centralize legacy planned meal migration on page load

### DIFF
--- a/src/lib/features/nutrition/migration.ts
+++ b/src/lib/features/nutrition/migration.ts
@@ -93,3 +93,15 @@ export async function migrateLegacyPlannedMealToPlanSlot(
 
   return { notice: LEGACY_PLANNED_MEAL_NOTICE };
 }
+
+export async function loadWithLegacyPlannedMealMigration<T>(
+  db: HealthDatabase,
+  localDay: string,
+  loadData: () => Promise<T>
+): Promise<{ data: T; notice: string | null }> {
+  const migration = await migrateLegacyPlannedMealToPlanSlot(db, localDay);
+  return {
+    data: await loadData(),
+    notice: migration.notice,
+  };
+}

--- a/src/lib/features/nutrition/state.ts
+++ b/src/lib/features/nutrition/state.ts
@@ -7,7 +7,7 @@ import type {
   RecipeCatalogItem,
 } from '$lib/core/domain/types';
 import { createNutritionForm, mergeNutritionFormWithDraft, type NutritionFormState } from './model';
-import { migrateLegacyPlannedMealToPlanSlot } from './migration';
+import { loadWithLegacyPlannedMealMigration } from './migration';
 import { getNutritionPlannedMealResolution } from './planned-meal-resolution';
 import {
   attachNutrientsToFoodEntry,
@@ -120,7 +120,19 @@ export async function loadNutritionPage(
   localDay: string,
   state: NutritionPageState
 ): Promise<NutritionPageState> {
-  const migration = await migrateLegacyPlannedMealToPlanSlot(db, localDay);
+  const { data, notice } = await loadWithLegacyPlannedMealMigration(
+    db,
+    localDay,
+    async () =>
+      await Promise.all([
+        buildDailyNutritionSummary(db, localDay),
+        listFavoriteMeals(db),
+        listFoodCatalogItems(db),
+        listRecipeCatalogItems(db),
+        getNutritionPlannedMealResolution(db, localDay),
+        buildNutritionRecommendationContext(db, localDay),
+      ])
+  );
   const [
     summary,
     favoriteMeals,
@@ -128,20 +140,13 @@ export async function loadNutritionPage(
     recipeCatalogItems,
     plannedMeal,
     recommendationContext,
-  ] = await Promise.all([
-    buildDailyNutritionSummary(db, localDay),
-    listFavoriteMeals(db),
-    listFoodCatalogItems(db),
-    listRecipeCatalogItems(db),
-    getNutritionPlannedMealResolution(db, localDay),
-    buildNutritionRecommendationContext(db, localDay),
-  ]);
+  ] = data;
 
   return {
     ...state,
     loading: false,
     localDay,
-    saveNotice: migration.notice ?? state.saveNotice,
+    saveNotice: notice ?? state.saveNotice,
     summary,
     favoriteMeals,
     catalogItems,

--- a/src/lib/features/planning/state.ts
+++ b/src/lib/features/planning/state.ts
@@ -5,7 +5,7 @@ import type {
   WeeklyPlan,
   WorkoutTemplate,
 } from '$lib/core/domain/types';
-import { migrateLegacyPlannedMealToPlanSlot } from '$lib/features/nutrition/migration';
+import { loadWithLegacyPlannedMealMigration } from '$lib/features/nutrition/migration';
 import { createPlanningSlotForm, type PlanningSlotFormState } from './model';
 import { getWeeklyPlanSnapshot } from './service';
 import {
@@ -76,14 +76,17 @@ export async function loadPlanningPage(
   localDay: string,
   state: PlanningPageState
 ): Promise<PlanningPageState> {
-  const migration = await migrateLegacyPlannedMealToPlanSlot(db, localDay);
-  const snapshot = await getWeeklyPlanSnapshot(db, localDay);
+  const { data: snapshot, notice } = await loadWithLegacyPlannedMealMigration(
+    db,
+    localDay,
+    async () => await getWeeklyPlanSnapshot(db, localDay)
+  );
   return {
     ...state,
     ...emptyPlanningNotices(),
     loading: false,
     localDay,
-    planNotice: migration.notice ?? '',
+    planNotice: notice ?? '',
     weeklyPlan: snapshot.weeklyPlan,
     weekDays: snapshot.weekDays,
     slots: snapshot.slots,

--- a/src/lib/features/review/controller.ts
+++ b/src/lib/features/review/controller.ts
@@ -1,5 +1,5 @@
 import type { HealthDatabase } from '$lib/core/db/types';
-import { migrateLegacyPlannedMealToPlanSlot } from '$lib/features/nutrition/migration';
+import { loadWithLegacyPlannedMealMigration } from '$lib/features/nutrition/migration';
 import type { WeeklyReviewData } from '$lib/features/review/service';
 import { buildWeeklySnapshot, saveNextWeekExperiment } from '$lib/features/review/service';
 
@@ -27,14 +27,17 @@ export async function loadReviewPage(
   db: HealthDatabase,
   localDay: string
 ): Promise<ReviewPageState> {
-  const migration = await migrateLegacyPlannedMealToPlanSlot(db, localDay);
-  const weekly = await buildWeeklySnapshot(db, localDay);
+  const { data: weekly, notice } = await loadWithLegacyPlannedMealMigration(
+    db,
+    localDay,
+    async () => await buildWeeklySnapshot(db, localDay)
+  );
   return {
     loading: false,
     localDay,
     weekly,
     selectedExperiment: weekly.experimentOptions[0] ?? '',
-    loadNotice: migration.notice ?? '',
+    loadNotice: notice ?? '',
     saveNotice: '',
   };
 }

--- a/src/lib/features/today/controller.ts
+++ b/src/lib/features/today/controller.ts
@@ -1,5 +1,4 @@
 import type { HealthDatabase } from '$lib/core/db/types';
-import { migrateLegacyPlannedMealToPlanSlot } from '$lib/features/nutrition/migration';
 import {
   createDailyCheckinPayload,
   createTodayForm,
@@ -10,6 +9,7 @@ import {
   clearTodayPlannedMeal,
   getTodaySnapshot,
   logPlannedMealForToday,
+  loadTodaySnapshotWithNotice,
   saveDailyCheckin,
   updateTodayPlanSlotStatus,
   type TodaySnapshot,
@@ -63,10 +63,9 @@ async function reloadTodayPageState(
 }
 
 export async function loadTodayPage(db: HealthDatabase, localDay: string): Promise<TodayPageState> {
-  const migration = await migrateLegacyPlannedMealToPlanSlot(db, localDay);
-  const snapshot = await getTodaySnapshot(db, localDay);
+  const { snapshot, notice } = await loadTodaySnapshotWithNotice(db, localDay);
   return createLoadedTodayPageState(createTodayPageState(), localDay, snapshot, {
-    saveNotice: migration.notice ?? '',
+    saveNotice: notice ?? '',
   });
 }
 

--- a/src/lib/features/today/snapshot.ts
+++ b/src/lib/features/today/snapshot.ts
@@ -13,7 +13,7 @@ import {
   listFoodCatalogItems,
   listRecipeCatalogItems,
 } from '$lib/features/nutrition/service';
-import { migrateLegacyPlannedMealToPlanSlot } from '$lib/features/nutrition/migration';
+import { loadWithLegacyPlannedMealMigration } from '$lib/features/nutrition/migration';
 import {
   getNutritionPlannedMealResolution,
   resolveNutritionPlannedMeal,
@@ -133,12 +133,15 @@ export async function getTodayPlannedMealResolution(
   db: HealthDatabase,
   date: string
 ): Promise<NutritionPlannedMealResolution> {
-  await migrateLegacyPlannedMealToPlanSlot(db, date);
-  return await getNutritionPlannedMealResolution(db, date);
+  const { data } = await loadWithLegacyPlannedMealMigration(
+    db,
+    date,
+    async () => await getNutritionPlannedMealResolution(db, date)
+  );
+  return data;
 }
 
-export async function getTodaySnapshot(db: HealthDatabase, date: string): Promise<TodaySnapshot> {
-  await migrateLegacyPlannedMealToPlanSlot(db, date);
+async function buildTodaySnapshotData(db: HealthDatabase, date: string): Promise<TodaySnapshot> {
   const [
     dailyRecord,
     nutritionSummary,
@@ -204,5 +207,29 @@ export async function getTodaySnapshot(db: HealthDatabase, date: string): Promis
     planItems,
     events,
     latestJournalEntry,
+  };
+}
+
+export async function getTodaySnapshot(db: HealthDatabase, date: string): Promise<TodaySnapshot> {
+  const { data } = await loadWithLegacyPlannedMealMigration(
+    db,
+    date,
+    async () => await buildTodaySnapshotData(db, date)
+  );
+  return data;
+}
+
+export async function loadTodaySnapshotWithNotice(
+  db: HealthDatabase,
+  date: string
+): Promise<{ snapshot: TodaySnapshot; notice: string | null }> {
+  const { data, notice } = await loadWithLegacyPlannedMealMigration(
+    db,
+    date,
+    async () => await buildTodaySnapshotData(db, date)
+  );
+  return {
+    snapshot: data,
+    notice,
   };
 }


### PR DESCRIPTION
## Summary
- centralize legacy planned-meal migration behind one shared migration-aware page-load helper
- remove duplicate migration calls from the Today runtime path while keeping the current behavior intact
- keep the tranche scoped to Nutrition, Plan, Review, and Today load semantics only

## Verification
- bun run test:unit -- tests/features/unit/nutrition/controller.test.ts tests/features/unit/planning/controller.test.ts tests/features/unit/review/controller.test.ts tests/features/unit/today/controller.test.ts tests/features/unit/today/service.test.ts
- bun run test:component -- tests/features/component/nutrition/NutritionPage.spec.ts tests/features/component/planning/PlanPage.spec.ts tests/features/component/review/ReviewPage.spec.ts tests/features/component/today/TodayPage.spec.ts
- bun run test:e2e -- tests/features/e2e/daily-flows.e2e.ts --grep legacy planned meal migrates when today loads
- bun run check:ci

## Summary by Sourcery

Centralize legacy planned-meal migration into a shared page-load helper and route its notice through Nutrition, Planning, Review, and Today page loads while preserving existing behavior.

Enhancements:
- Introduce a generic load helper that runs the legacy planned-meal migration and returns both loaded data and any migration notice.
- Update Nutrition, Planning, and Review page loaders to use the shared migration-aware helper instead of performing migrations inline.
- Refactor Today snapshot building to use the shared migration helper and expose a notice-aware snapshot loader consumed by the Today controller.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the legacy planned-meal migration into a shared page-load helper to remove duplicate calls and keep notices consistent across Nutrition, Planning, Review, and Today. This simplifies load paths and preserves current behavior.

- **Refactors**
  - Added `loadWithLegacyPlannedMealMigration(db, localDay, loadData)` to run migration and return `{ data, notice }`.
  - Switched page loaders to the helper: Nutrition (`loadNutritionPage`), Planning (`loadPlanningPage`), Review (`loadReviewPage`); Today via `getTodayPlannedMealResolution`, `getTodaySnapshot`, and new `loadTodaySnapshotWithNotice`.
  - Routed migration notices to existing fields (`saveNotice`, `planNotice`, `loadNotice`) and removed direct migration calls from Today’s controller.
  - Scope limited to Nutrition, Plan, Review, and Today load semantics only.

<sup>Written for commit 67af12ded7024d8d4bfab41f6626d817898fdcd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

