### PR TITLE
Validate wedge action routes with explicit contracts

### DIFF
--- a/src/lib/features/groceries/contracts.ts
+++ b/src/lib/features/groceries/contracts.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import type { GroceriesPageState, ManualGroceryDraft } from './controller';
+
+function isGroceriesPageState(value: unknown): value is GroceriesPageState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as Record<string, unknown>;
+
+  return (
+    typeof state.loading === 'boolean' &&
+    typeof state.localDay === 'string' &&
+    typeof state.saveNotice === 'string' &&
+    (state.weeklyPlan === null ||
+      (typeof state.weeklyPlan === 'object' && state.weeklyPlan !== null)) &&
+    Array.isArray(state.groceryItems) &&
+    Array.isArray(state.groceryWarnings) &&
+    Array.isArray(state.recipeCatalogItems)
+  );
+}
+
+const groceriesPageStateSchema = z.custom<GroceriesPageState>(isGroceriesPageState, {
+  message: 'Invalid groceries page state',
+});
+
+const manualGroceryDraftSchema = z.object({
+  label: z.string(),
+  quantityText: z.string(),
+}) satisfies z.ZodType<ManualGroceryDraft>;
+
+export const groceriesRequestSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('load'),
+    localDay: z.string(),
+  }),
+  z.object({
+    action: z.literal('toggle'),
+    state: groceriesPageStateSchema,
+    itemId: z.string(),
+    patch: z.object({
+      checked: z.boolean(),
+      excluded: z.boolean(),
+      onHand: z.boolean(),
+    }),
+  }),
+  z.object({
+    action: z.literal('addManual'),
+    state: groceriesPageStateSchema,
+    draft: manualGroceryDraftSchema,
+  }),
+  z.object({
+    action: z.literal('removeManual'),
+    state: groceriesPageStateSchema,
+    itemId: z.string(),
+  }),
+]);
+
+export type GroceriesRequest = z.infer<typeof groceriesRequestSchema>;

--- a/src/lib/features/nutrition/contracts.ts
+++ b/src/lib/features/nutrition/contracts.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+import type {
+  NutritionCatalogItemDraft,
+  NutritionMealDraft,
+  NutritionPageState,
+  NutritionPlannedMealDraft,
+  NutritionRecurringMealDraft,
+} from './controller';
+
+function isNutritionPageState(value: unknown): value is NutritionPageState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as Record<string, unknown>;
+  const summary = state.summary as Record<string, unknown> | undefined;
+  const form = state.form as Record<string, unknown> | undefined;
+  const recommendationContext = state.recommendationContext as Record<string, unknown> | undefined;
+
+  return (
+    typeof state.loading === 'boolean' &&
+    typeof state.localDay === 'string' &&
+    typeof state.saveNotice === 'string' &&
+    typeof state.searchNotice === 'string' &&
+    typeof state.packagedNotice === 'string' &&
+    typeof state.recipeNotice === 'string' &&
+    summary !== undefined &&
+    typeof summary.calories === 'number' &&
+    typeof summary.protein === 'number' &&
+    typeof summary.fiber === 'number' &&
+    typeof summary.carbs === 'number' &&
+    typeof summary.fat === 'number' &&
+    Array.isArray(summary.entries) &&
+    Array.isArray(state.favoriteMeals) &&
+    Array.isArray(state.catalogItems) &&
+    Array.isArray(state.recipeCatalogItems) &&
+    (state.plannedMeal === null ||
+      (typeof state.plannedMeal === 'object' && state.plannedMeal !== null)) &&
+    typeof state.plannedMealIssue === 'string' &&
+    (state.plannedMealSlotId === null || typeof state.plannedMealSlotId === 'string') &&
+    typeof state.searchQuery === 'string' &&
+    Array.isArray(state.matches) &&
+    typeof state.packagedQuery === 'string' &&
+    typeof state.barcodeQuery === 'string' &&
+    Array.isArray(state.packagedMatches) &&
+    typeof state.recipeQuery === 'string' &&
+    Array.isArray(state.recipeMatches) &&
+    (state.selectedMatch === null ||
+      (typeof state.selectedMatch === 'object' && state.selectedMatch !== null)) &&
+    form !== undefined &&
+    typeof form.mealType === 'string' &&
+    typeof form.name === 'string' &&
+    typeof form.calories === 'string' &&
+    typeof form.protein === 'string' &&
+    typeof form.fiber === 'string' &&
+    typeof form.carbs === 'string' &&
+    typeof form.fat === 'string' &&
+    typeof form.notes === 'string' &&
+    recommendationContext !== undefined &&
+    typeof recommendationContext.anxietyCount === 'number' &&
+    typeof recommendationContext.symptomCount === 'number' &&
+    (recommendationContext.sleepHours === undefined ||
+      typeof recommendationContext.sleepHours === 'number') &&
+    (recommendationContext.sleepQuality === undefined ||
+      typeof recommendationContext.sleepQuality === 'number')
+  );
+}
+
+const nutritionPageStateSchema = z.custom<NutritionPageState>(isNutritionPageState, {
+  message: 'Invalid nutrition page state',
+});
+
+const nutritionMealDraftSchema = z.object({
+  localDay: z.string(),
+  mealType: z.string(),
+  name: z.string(),
+  calories: z.number(),
+  protein: z.number(),
+  fiber: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+  notes: z.string(),
+}) satisfies z.ZodType<NutritionMealDraft>;
+
+const nutritionRecurringMealDraftSchema = z.object({
+  mealType: z.string(),
+  name: z.string(),
+  calories: z.number(),
+  protein: z.number(),
+  fiber: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+  sourceName: z.string().optional(),
+}) satisfies z.ZodType<NutritionRecurringMealDraft>;
+
+const nutritionPlannedMealDraftSchema = nutritionRecurringMealDraftSchema.extend({
+  notes: z.string(),
+  foodCatalogItemId: z.string().optional(),
+}) satisfies z.ZodType<NutritionPlannedMealDraft>;
+
+const nutritionCatalogItemDraftSchema = z.object({
+  name: z.string(),
+  calories: z.number(),
+  protein: z.number(),
+  fiber: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+}) satisfies z.ZodType<NutritionCatalogItemDraft>;
+
+export const nutritionRequestSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('load'),
+    localDay: z.string(),
+    state: nutritionPageStateSchema,
+  }),
+  z.object({
+    action: z.literal('saveMeal'),
+    state: nutritionPageStateSchema,
+    draft: nutritionMealDraftSchema,
+  }),
+  z.object({
+    action: z.literal('planMeal'),
+    state: nutritionPageStateSchema,
+    draft: nutritionPlannedMealDraftSchema,
+  }),
+  z.object({
+    action: z.literal('saveRecurringMeal'),
+    state: nutritionPageStateSchema,
+    draft: nutritionRecurringMealDraftSchema,
+  }),
+  z.object({
+    action: z.literal('saveCatalogItem'),
+    state: nutritionPageStateSchema,
+    draft: nutritionCatalogItemDraftSchema,
+  }),
+  z.object({
+    action: z.literal('clearPlannedMeal'),
+    state: nutritionPageStateSchema,
+  }),
+  z.object({
+    action: z.literal('reuseMeal'),
+    state: nutritionPageStateSchema,
+    favoriteMealId: z.string(),
+  }),
+]);
+
+export type NutritionRequest = z.infer<typeof nutritionRequestSchema>;

--- a/src/lib/features/review/contracts.ts
+++ b/src/lib/features/review/contracts.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import type { ReviewPageState } from './controller';
+
+function isReviewPageState(value: unknown): value is ReviewPageState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as Record<string, unknown>;
+
+  return (
+    typeof state.loading === 'boolean' &&
+    typeof state.localDay === 'string' &&
+    typeof state.selectedExperiment === 'string' &&
+    typeof state.loadNotice === 'string' &&
+    typeof state.saveNotice === 'string' &&
+    (state.weekly === null || (typeof state.weekly === 'object' && state.weekly !== null))
+  );
+}
+
+const reviewPageStateSchema = z.custom<ReviewPageState>(isReviewPageState, {
+  message: 'Invalid review page state',
+});
+
+export const reviewRequestSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('load'),
+    localDay: z.string(),
+  }),
+  z.object({
+    action: z.literal('saveExperiment'),
+    state: reviewPageStateSchema,
+  }),
+]);
+
+export type ReviewRequest = z.infer<typeof reviewRequestSchema>;

--- a/src/lib/features/today/contracts.ts
+++ b/src/lib/features/today/contracts.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import type { TodayPageState } from './controller';
+
+function isTodayPageState(value: unknown): value is TodayPageState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as Record<string, unknown>;
+  const form = state.form as Record<string, unknown> | undefined;
+
+  return (
+    typeof state.loading === 'boolean' &&
+    typeof state.saving === 'boolean' &&
+    typeof state.saveNotice === 'string' &&
+    typeof state.todayDate === 'string' &&
+    (state.snapshot === null || (typeof state.snapshot === 'object' && state.snapshot !== null)) &&
+    form !== undefined &&
+    typeof form.mood === 'string' &&
+    typeof form.energy === 'string' &&
+    typeof form.stress === 'string' &&
+    typeof form.focus === 'string' &&
+    typeof form.sleepHours === 'string' &&
+    typeof form.sleepQuality === 'string' &&
+    typeof form.freeformNote === 'string'
+  );
+}
+
+const todayPageStateSchema = z.custom<TodayPageState>(isTodayPageState, {
+  message: 'Invalid today page state',
+});
+
+export const todayRequestSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('load'),
+    localDay: z.string(),
+  }),
+  z.object({
+    action: z.literal('save'),
+    state: todayPageStateSchema,
+  }),
+  z.object({
+    action: z.literal('logPlannedMeal'),
+    state: todayPageStateSchema,
+  }),
+  z.object({
+    action: z.literal('clearPlannedMeal'),
+    state: todayPageStateSchema,
+  }),
+  z.object({
+    action: z.literal('markPlanSlotStatus'),
+    state: todayPageStateSchema,
+    slotId: z.string(),
+    status: z.enum(['planned', 'done', 'skipped']),
+  }),
+]);
+
+export type TodayRequest = z.infer<typeof todayRequestSchema>;

--- a/src/routes/api/groceries/+server.ts
+++ b/src/routes/api/groceries/+server.ts
@@ -4,32 +4,26 @@ import {
   loadGroceriesPage,
   removeManualGroceryItemPage,
   toggleGroceryItemPage,
-  type ManualGroceryDraft,
   type GroceriesPageState,
 } from '$lib/features/groceries/controller';
+import { groceriesRequestSchema, type GroceriesRequest } from '$lib/features/groceries/contracts';
 
-type GroceriesRequest =
-  | { action: 'load'; localDay: string }
-  | {
-      action: 'toggle';
-      state: GroceriesPageState;
-      itemId: string;
-      patch: { checked: boolean; excluded: boolean; onHand: boolean };
-    }
-  | {
-      action: 'addManual';
-      state: GroceriesPageState;
-      draft: ManualGroceryDraft;
-    }
-  | {
-      action: 'removeManual';
-      state: GroceriesPageState;
-      itemId: string;
-    };
-
-export const POST = createDbActionPostHandler<GroceriesRequest, GroceriesPageState>({
-  load: (db, body) => loadGroceriesPage(db, body.localDay),
-  toggle: (db, body) => toggleGroceryItemPage(db, body.state, body.itemId, body.patch),
-  addManual: (db, body) => addManualGroceryItemPage(db, body.state, body.draft),
-  removeManual: (db, body) => removeManualGroceryItemPage(db, body.state, body.itemId),
-});
+export const POST = createDbActionPostHandler<GroceriesRequest, GroceriesPageState>(
+  {
+    load: (db, body) => loadGroceriesPage(db, body.localDay),
+    toggle: (db, body) => toggleGroceryItemPage(db, body.state, body.itemId, body.patch),
+    addManual: (db, body) => addManualGroceryItemPage(db, body.state, body.draft),
+    removeManual: (db, body) => removeManualGroceryItemPage(db, body.state, body.itemId),
+  },
+  undefined,
+  {
+    parseBody: async (request) => {
+      const parsed = groceriesRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid groceries request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid groceries request payload.', { status: 400 }),
+  }
+);

--- a/src/routes/api/nutrition/+server.ts
+++ b/src/routes/api/nutrition/+server.ts
@@ -7,28 +7,29 @@ import {
   saveNutritionCatalogItem,
   saveNutritionMeal,
   saveNutritionRecurringMeal,
-  type NutritionCatalogItemDraft,
-  type NutritionMealDraft,
   type NutritionPageState,
-  type NutritionPlannedMealDraft,
-  type NutritionRecurringMealDraft,
 } from '$lib/features/nutrition/controller';
+import { nutritionRequestSchema, type NutritionRequest } from '$lib/features/nutrition/contracts';
 
-type NutritionRequest =
-  | { action: 'load'; localDay: string; state: NutritionPageState }
-  | { action: 'saveMeal'; state: NutritionPageState; draft: NutritionMealDraft }
-  | { action: 'planMeal'; state: NutritionPageState; draft: NutritionPlannedMealDraft }
-  | { action: 'saveRecurringMeal'; state: NutritionPageState; draft: NutritionRecurringMealDraft }
-  | { action: 'saveCatalogItem'; state: NutritionPageState; draft: NutritionCatalogItemDraft }
-  | { action: 'clearPlannedMeal'; state: NutritionPageState }
-  | { action: 'reuseMeal'; state: NutritionPageState; favoriteMealId: string };
-
-export const POST = createDbActionPostHandler<NutritionRequest, NutritionPageState>({
-  load: (db, body) => loadNutritionPage(db, body.localDay, body.state),
-  saveMeal: (db, body) => saveNutritionMeal(db, body.state, body.draft),
-  planMeal: (db, body) => planNutritionMeal(db, body.state, body.draft),
-  saveRecurringMeal: (db, body) => saveNutritionRecurringMeal(db, body.state, body.draft),
-  saveCatalogItem: (db, body) => saveNutritionCatalogItem(db, body.state, body.draft),
-  clearPlannedMeal: (db, body) => clearNutritionPlannedMeal(db, body.state),
-  reuseMeal: (db, body) => reuseNutritionMeal(db, body.state, body.favoriteMealId),
-});
+export const POST = createDbActionPostHandler<NutritionRequest, NutritionPageState>(
+  {
+    load: (db, body) => loadNutritionPage(db, body.localDay, body.state),
+    saveMeal: (db, body) => saveNutritionMeal(db, body.state, body.draft),
+    planMeal: (db, body) => planNutritionMeal(db, body.state, body.draft),
+    saveRecurringMeal: (db, body) => saveNutritionRecurringMeal(db, body.state, body.draft),
+    saveCatalogItem: (db, body) => saveNutritionCatalogItem(db, body.state, body.draft),
+    clearPlannedMeal: (db, body) => clearNutritionPlannedMeal(db, body.state),
+    reuseMeal: (db, body) => reuseNutritionMeal(db, body.state, body.favoriteMealId),
+  },
+  undefined,
+  {
+    parseBody: async (request) => {
+      const parsed = nutritionRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid nutrition request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid nutrition request payload.', { status: 400 }),
+  }
+);

--- a/src/routes/api/review/+server.ts
+++ b/src/routes/api/review/+server.ts
@@ -4,12 +4,22 @@ import {
   saveReviewExperimentPage,
   type ReviewPageState,
 } from '$lib/features/review/controller';
+import { reviewRequestSchema, type ReviewRequest } from '$lib/features/review/contracts';
 
-type ReviewRequest =
-  | { action: 'load'; localDay: string }
-  | { action: 'saveExperiment'; state: ReviewPageState };
-
-export const POST = createDbActionPostHandler<ReviewRequest, ReviewPageState>({
-  load: (db, body) => loadReviewPage(db, body.localDay),
-  saveExperiment: (db, body) => saveReviewExperimentPage(db, body.state),
-});
+export const POST = createDbActionPostHandler<ReviewRequest, ReviewPageState>(
+  {
+    load: (db, body) => loadReviewPage(db, body.localDay),
+    saveExperiment: (db, body) => saveReviewExperimentPage(db, body.state),
+  },
+  undefined,
+  {
+    parseBody: async (request) => {
+      const parsed = reviewRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid review request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid review request payload.', { status: 400 }),
+  }
+);

--- a/src/routes/api/today/+server.ts
+++ b/src/routes/api/today/+server.ts
@@ -7,24 +7,26 @@ import {
   saveTodayPage,
   type TodayPageState,
 } from '$lib/features/today/controller';
+import { todayRequestSchema, type TodayRequest } from '$lib/features/today/contracts';
 
-type TodayRequest =
-  | { action: 'load'; localDay: string }
-  | { action: 'save'; state: TodayPageState }
-  | { action: 'logPlannedMeal'; state: TodayPageState }
-  | { action: 'clearPlannedMeal'; state: TodayPageState }
-  | {
-      action: 'markPlanSlotStatus';
-      state: TodayPageState;
-      slotId: string;
-      status: 'planned' | 'done' | 'skipped';
-    };
-
-export const POST = createDbActionPostHandler<TodayRequest, TodayPageState>({
-  load: (db, body) => loadTodayPage(db, body.localDay),
-  save: (db, body) => saveTodayPage(db, body.state),
-  logPlannedMeal: (db, body) => logTodayPlannedMealPage(db, body.state),
-  clearPlannedMeal: (db, body) => clearTodayPlannedMealPage(db, body.state),
-  markPlanSlotStatus: (db, body) =>
-    markTodayPlanSlotStatusPage(db, body.state, body.slotId, body.status),
-});
+export const POST = createDbActionPostHandler<TodayRequest, TodayPageState>(
+  {
+    load: (db, body) => loadTodayPage(db, body.localDay),
+    save: (db, body) => saveTodayPage(db, body.state),
+    logPlannedMeal: (db, body) => logTodayPlannedMealPage(db, body.state),
+    clearPlannedMeal: (db, body) => clearTodayPlannedMealPage(db, body.state),
+    markPlanSlotStatus: (db, body) =>
+      markTodayPlanSlotStatusPage(db, body.state, body.slotId, body.status),
+  },
+  undefined,
+  {
+    parseBody: async (request) => {
+      const parsed = todayRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid today request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid today request payload.', { status: 400 }),
+  }
+);

--- a/tests/features/unit/groceries/route.test.ts
+++ b/tests/features/unit/groceries/route.test.ts
@@ -24,12 +24,18 @@ describe('groceries route', () => {
     vi.doMock('$lib/server/http/action-route', () => ({
       ...actual,
       createDbActionPostHandler: (
-        handlers: Parameters<typeof actual.createDbActionPostHandler>[0]
+        handlers: Parameters<typeof actual.createDbActionPostHandler>[0],
+        _deps: Parameters<typeof actual.createDbActionPostHandler>[1],
+        options: Parameters<typeof actual.createDbActionPostHandler>[2]
       ) =>
-        actual.createDbActionPostHandler(handlers, {
-          withDb: async (run) => await run(db),
-          toResponse: (body) => Response.json(body),
-        }),
+        actual.createDbActionPostHandler(
+          handlers,
+          {
+            withDb: async (run) => await run(db),
+            toResponse: (body) => Response.json(body),
+          },
+          options
+        ),
     }));
     vi.doMock('$lib/features/groceries/controller', () => ({
       loadGroceriesPage:
@@ -224,5 +230,21 @@ describe('groceries route', () => {
       })
     );
     expect(removeManualGroceryItemPage).toHaveBeenCalledWith(db, state, 'grocery-1');
+  });
+
+  it('returns 400 for invalid grocery action payloads', async () => {
+    const loadGroceriesPage = vi.fn();
+    const { POST } = await importRoute({ loadGroceriesPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/groceries', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'toggle', localDay: '2026-04-07' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid groceries request payload.');
+    expect(loadGroceriesPage).not.toHaveBeenCalled();
   });
 });

--- a/tests/features/unit/nutrition/action-route.test.ts
+++ b/tests/features/unit/nutrition/action-route.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { HealthDatabase } from '$lib/core/db/types';
+
+function createNutritionRouteState() {
+  return {
+    loading: false,
+    localDay: '2026-04-04',
+    saveNotice: '',
+    searchNotice: '',
+    packagedNotice: '',
+    recipeNotice: '',
+    summary: {
+      calories: 0,
+      protein: 0,
+      fiber: 0,
+      carbs: 0,
+      fat: 0,
+      entries: [],
+    },
+    favoriteMeals: [],
+    catalogItems: [],
+    recipeCatalogItems: [],
+    plannedMeal: null,
+    plannedMealIssue: '',
+    plannedMealSlotId: null,
+    searchQuery: '',
+    matches: [],
+    packagedQuery: '',
+    barcodeQuery: '',
+    packagedMatches: [],
+    recipeQuery: '',
+    recipeMatches: [],
+    selectedMatch: null,
+    form: {
+      mealType: 'breakfast',
+      name: '',
+      calories: '0',
+      protein: '0',
+      fiber: '0',
+      carbs: '0',
+      fat: '0',
+      notes: '',
+    },
+    recommendationContext: {
+      anxietyCount: 0,
+      symptomCount: 0,
+    },
+  };
+}
+
+describe('nutrition action route', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/features/nutrition/controller');
+    vi.doUnmock('$lib/server/http/action-route');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function importRoute(overrides: {
+    db?: HealthDatabase;
+    loadNutritionPage?: ReturnType<typeof vi.fn>;
+    saveNutritionMeal?: ReturnType<typeof vi.fn>;
+    planNutritionMeal?: ReturnType<typeof vi.fn>;
+    saveNutritionRecurringMeal?: ReturnType<typeof vi.fn>;
+    saveNutritionCatalogItem?: ReturnType<typeof vi.fn>;
+    clearNutritionPlannedMeal?: ReturnType<typeof vi.fn>;
+    reuseNutritionMeal?: ReturnType<typeof vi.fn>;
+  }) {
+    const db = overrides.db ?? ({} as HealthDatabase);
+    const actual = await vi.importActual<typeof import('$lib/server/http/action-route')>(
+      '$lib/server/http/action-route'
+    );
+
+    vi.doMock('$lib/server/http/action-route', () => ({
+      ...actual,
+      createDbActionPostHandler: (
+        handlers: Parameters<typeof actual.createDbActionPostHandler>[0],
+        _deps: Parameters<typeof actual.createDbActionPostHandler>[1],
+        options: Parameters<typeof actual.createDbActionPostHandler>[2]
+      ) =>
+        actual.createDbActionPostHandler(
+          handlers,
+          {
+            withDb: async (run) => await run(db),
+            toResponse: (body) => Response.json(body),
+          },
+          options
+        ),
+    }));
+
+    const pageState = createNutritionRouteState();
+
+    vi.doMock('$lib/features/nutrition/controller', () => ({
+      loadNutritionPage: overrides.loadNutritionPage ?? vi.fn(async () => pageState),
+      saveNutritionMeal:
+        overrides.saveNutritionMeal ??
+        vi.fn(async () => ({
+          ...pageState,
+          saveNotice: 'Meal saved.',
+        })),
+      planNutritionMeal:
+        overrides.planNutritionMeal ??
+        vi.fn(async () => ({
+          ...pageState,
+          saveNotice: 'Planned next meal saved.',
+        })),
+      saveNutritionRecurringMeal:
+        overrides.saveNutritionRecurringMeal ??
+        vi.fn(async () => ({
+          ...pageState,
+          saveNotice: 'Recurring meal saved.',
+        })),
+      saveNutritionCatalogItem:
+        overrides.saveNutritionCatalogItem ??
+        vi.fn(async () => ({
+          ...pageState,
+          saveNotice: 'Saved to custom food catalog.',
+        })),
+      clearNutritionPlannedMeal:
+        overrides.clearNutritionPlannedMeal ??
+        vi.fn(async () => ({
+          ...pageState,
+          saveNotice: 'Planned meal cleared.',
+        })),
+      reuseNutritionMeal:
+        overrides.reuseNutritionMeal ??
+        vi.fn(async () => ({
+          ...pageState,
+          saveNotice: 'Recurring meal reused.',
+        })),
+    }));
+
+    return {
+      pageState,
+      route: await import('../../../../src/routes/api/nutrition/+server.ts'),
+    };
+  }
+
+  it('loads nutrition page state through the action route', async () => {
+    const db = {} as HealthDatabase;
+    const loadNutritionPage = vi.fn(async () => createNutritionRouteState());
+    const {
+      pageState,
+      route: { POST },
+    } = await importRoute({ db, loadNutritionPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/nutrition', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'load', localDay: '2026-04-04', state: pageState }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        localDay: '2026-04-04',
+        loading: false,
+      })
+    );
+    expect(loadNutritionPage).toHaveBeenCalledWith(db, '2026-04-04', pageState);
+  });
+
+  it('dispatches nutrition write actions through the action route', async () => {
+    const db = {} as HealthDatabase;
+    const {
+      pageState,
+      route: { POST },
+    } = await importRoute({ db });
+
+    const saveMealResponse = await POST({
+      request: new Request('http://health.test/api/nutrition', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'saveMeal',
+          state: pageState,
+          draft: {
+            localDay: '2026-04-04',
+            mealType: 'breakfast',
+            name: 'Greek yogurt bowl',
+            calories: 310,
+            protein: 24,
+            fiber: 6,
+            carbs: 34,
+            fat: 8,
+            notes: '',
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(saveMealResponse.status).toBe(200);
+    expect(await saveMealResponse.json()).toEqual(
+      expect.objectContaining({ saveNotice: 'Meal saved.' })
+    );
+
+    const saveCatalogResponse = await POST({
+      request: new Request('http://health.test/api/nutrition', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'saveCatalogItem',
+          state: pageState,
+          draft: {
+            name: 'Greek yogurt bowl',
+            calories: 310,
+            protein: 24,
+            fiber: 6,
+            carbs: 34,
+            fat: 8,
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(saveCatalogResponse.status).toBe(200);
+    expect(await saveCatalogResponse.json()).toEqual(
+      expect.objectContaining({ saveNotice: 'Saved to custom food catalog.' })
+    );
+  });
+
+  it('returns 400 for invalid nutrition action payloads', async () => {
+    const loadNutritionPage = vi.fn();
+    const {
+      route: { POST },
+    } = await importRoute({ loadNutritionPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/nutrition', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'planMeal',
+          localDay: '2026-04-04',
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid nutrition request payload.');
+    expect(loadNutritionPage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/features/unit/review/route.test.ts
+++ b/tests/features/unit/review/route.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { HealthDatabase } from '$lib/core/db/types';
+
+describe('review route', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/features/review/controller');
+    vi.doUnmock('$lib/server/http/action-route');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function importRoute(overrides: {
+    db?: HealthDatabase;
+    loadReviewPage?: ReturnType<typeof vi.fn>;
+    saveReviewExperimentPage?: ReturnType<typeof vi.fn>;
+  }) {
+    const db = overrides.db ?? ({} as HealthDatabase);
+    const actual = await vi.importActual<typeof import('$lib/server/http/action-route')>(
+      '$lib/server/http/action-route'
+    );
+
+    vi.doMock('$lib/server/http/action-route', () => ({
+      ...actual,
+      createDbActionPostHandler: (
+        handlers: Parameters<typeof actual.createDbActionPostHandler>[0],
+        _deps: Parameters<typeof actual.createDbActionPostHandler>[1],
+        options: Parameters<typeof actual.createDbActionPostHandler>[2]
+      ) =>
+        actual.createDbActionPostHandler(
+          handlers,
+          {
+            withDb: async (run) => await run(db),
+            toResponse: (body) => Response.json(body),
+          },
+          options
+        ),
+    }));
+    vi.doMock('$lib/features/review/controller', () => ({
+      loadReviewPage:
+        overrides.loadReviewPage ??
+        vi.fn(async () => ({
+          loading: false,
+          localDay: '2026-04-04',
+          weekly: null,
+          selectedExperiment: '',
+          loadNotice: '',
+          saveNotice: '',
+        })),
+      saveReviewExperimentPage:
+        overrides.saveReviewExperimentPage ??
+        vi.fn(async (database: HealthDatabase, state: unknown) => ({
+          ...(state as object),
+          saveNotice: 'Experiment saved.',
+        })),
+    }));
+
+    return await import('../../../../src/routes/api/review/+server.ts');
+  }
+
+  it('loads review page state through the action route', async () => {
+    const db = {} as HealthDatabase;
+    const loadReviewPage = vi.fn(async () => ({
+      loading: false,
+      localDay: '2026-04-04',
+      weekly: { experimentOptions: ['More protein'] },
+      selectedExperiment: 'More protein',
+      loadNotice: '',
+      saveNotice: '',
+    }));
+    const { POST } = await importRoute({ db, loadReviewPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/review', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'load', localDay: '2026-04-04' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        localDay: '2026-04-04',
+        loading: false,
+      })
+    );
+    expect(loadReviewPage).toHaveBeenCalledWith(db, '2026-04-04');
+  });
+
+  it('saves the selected review experiment through the action route', async () => {
+    const db = {} as HealthDatabase;
+    const state = {
+      loading: false,
+      localDay: '2026-04-04',
+      weekly: { experimentOptions: ['More protein'] },
+      selectedExperiment: 'More protein',
+      loadNotice: '',
+      saveNotice: '',
+    };
+    const saveReviewExperimentPage = vi.fn(async () => ({
+      ...state,
+      saveNotice: 'Experiment saved.',
+    }));
+    const { POST } = await importRoute({ db, saveReviewExperimentPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/review', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'saveExperiment', state }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ saveNotice: 'Experiment saved.' })
+    );
+    expect(saveReviewExperimentPage).toHaveBeenCalledWith(db, state);
+  });
+
+  it('returns 400 for invalid review action payloads', async () => {
+    const loadReviewPage = vi.fn();
+    const { POST } = await importRoute({ loadReviewPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/review', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'saveExperiment', localDay: '2026-04-04' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid review request payload.');
+    expect(loadReviewPage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/features/unit/today/route.test.ts
+++ b/tests/features/unit/today/route.test.ts
@@ -25,12 +25,18 @@ describe('today route', () => {
     vi.doMock('$lib/server/http/action-route', () => ({
       ...actual,
       createDbActionPostHandler: (
-        handlers: Parameters<typeof actual.createDbActionPostHandler>[0]
+        handlers: Parameters<typeof actual.createDbActionPostHandler>[0],
+        _deps: Parameters<typeof actual.createDbActionPostHandler>[1],
+        options: Parameters<typeof actual.createDbActionPostHandler>[2]
       ) =>
-        actual.createDbActionPostHandler(handlers, {
-          withDb: async (run) => await run(db),
-          toResponse: (body) => Response.json(body),
-        }),
+        actual.createDbActionPostHandler(
+          handlers,
+          {
+            withDb: async (run) => await run(db),
+            toResponse: (body) => Response.json(body),
+          },
+          options
+        ),
     }));
     vi.doMock('$lib/features/today/controller', () => ({
       loadTodayPage:
@@ -204,5 +210,24 @@ describe('today route', () => {
       expect.objectContaining({ saveNotice: 'Plan item marked done.' })
     );
     expect(markTodayPlanSlotStatusPage).toHaveBeenCalledWith(db, state, 'slot-1', 'done');
+  });
+
+  it('returns 400 for invalid today action payloads', async () => {
+    const loadTodayPage = vi.fn();
+    const { POST } = await importRoute({ loadTodayPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/today', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'markPlanSlotStatus',
+          localDay: '2026-04-04',
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid today request payload.');
+    expect(loadTodayPage).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add explicit request contracts for the wedge action routes in groceries, nutrition, review, and today
- reject malformed action payloads with 400 responses instead of loose JSON dispatch
- add focused route tests for the new parse-failure behavior and missing review/nutrition action-route coverage

## Verification
- bun run test:unit -- tests/features/unit/groceries/route.test.ts tests/features/unit/today/route.test.ts tests/features/unit/review/route.test.ts tests/features/unit/nutrition/action-route.test.ts tests/features/unit/nutrition/route.test.ts
- bun run check:ci

## Summary by Sourcery

Introduce explicit Zod-based request contracts for groceries, nutrition, today, and review action routes and wire them into the shared DB action handler with strict payload validation and 400 responses on parse failure.

Bug Fixes:
- Return HTTP 400 responses for malformed groceries, nutrition, today, and review action payloads instead of loosely dispatching invalid JSON bodies.

Enhancements:
- Extract typed request contract modules for groceries, nutrition, today, and review features to centralize and harden action payload validation.
- Extend action-route POST handler usage to accept custom body parsing and error handling hooks for feature routes.

Tests:
- Add and expand unit tests for groceries, nutrition, today, and review routes to cover successful dispatch flows and new 400 error behavior on invalid action payloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit `zod` request contracts for groceries, nutrition, review, and today action routes. Invalid action payloads now return 400 instead of being loosely dispatched, with focused route tests added.

- **Refactors**
  - Define discriminated-union request schemas in `contracts.ts` for each feature.
  - Validate bodies via `parseBody`/`onParseError` in `createDbActionPostHandler` for all four routes.
  - Remove inline request unions from route handlers; add tests for parse failures and missing action coverage.

<sup>Written for commit d821e289d5ffa5da45cfebd00524b66d9b55b211. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

