### PR TITLE
Validate nutrition and movement search routes

### DIFF
--- a/src/lib/features/movement/contracts.ts
+++ b/src/lib/features/movement/contracts.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import type { MovementPageState } from './controller';
+
+function isMovementPageState(value: unknown): value is MovementPageState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as Record<string, unknown>;
+  const form = state.workoutTemplateForm as Record<string, unknown> | undefined;
+
+  return (
+    typeof state.loading === 'boolean' &&
+    typeof state.saveNotice === 'string' &&
+    Array.isArray(state.workoutTemplates) &&
+    Array.isArray(state.exerciseCatalogItems) &&
+    typeof state.exerciseSearchQuery === 'string' &&
+    Array.isArray(state.exerciseSearchResults) &&
+    form !== undefined &&
+    typeof form.title === 'string' &&
+    typeof form.goal === 'string' &&
+    Array.isArray(form.exercises)
+  );
+}
+
+const movementPageStateSchema = z.custom<MovementPageState>(isMovementPageState, {
+  message: 'Invalid movement page state',
+});
+
+export const movementRequestSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('load'),
+  }),
+  z.object({
+    action: z.literal('saveWorkoutTemplate'),
+    state: movementPageStateSchema,
+  }),
+]);
+
+export type MovementRequest = z.infer<typeof movementRequestSchema>;
+
+export const movementQueryRequestSchema = z.object({
+  query: z.string().optional(),
+});
+
+export type MovementQueryRequest = z.infer<typeof movementQueryRequestSchema>;

--- a/src/lib/features/nutrition/contracts.ts
+++ b/src/lib/features/nutrition/contracts.ts
@@ -142,3 +142,13 @@ export const nutritionRequestSchema = z.discriminatedUnion('action', [
 ]);
 
 export type NutritionRequest = z.infer<typeof nutritionRequestSchema>;
+
+export const nutritionQueryRequestSchema = z.object({
+  query: z.string().optional(),
+});
+
+export type NutritionQueryRequest = z.infer<typeof nutritionQueryRequestSchema>;
+
+export const nutritionEnrichParamsSchema = z.object({
+  fdcId: z.string().trim().regex(/^\d+$/, 'Invalid USDA food id.'),
+});

--- a/src/routes/api/movement/+server.ts
+++ b/src/routes/api/movement/+server.ts
@@ -4,12 +4,22 @@ import {
   saveMovementWorkoutTemplatePage,
   type MovementPageState,
 } from '$lib/features/movement/controller';
+import { movementRequestSchema, type MovementRequest } from '$lib/features/movement/contracts';
 
-type MovementRequest =
-  | { action: 'load' }
-  | { action: 'saveWorkoutTemplate'; state: MovementPageState };
-
-export const POST = createDbActionPostHandler<MovementRequest, MovementPageState>({
-  load: (db) => loadMovementPage(db),
-  saveWorkoutTemplate: (db, body) => saveMovementWorkoutTemplatePage(db, body.state),
-});
+export const POST = createDbActionPostHandler<MovementRequest, MovementPageState>(
+  {
+    load: (db) => loadMovementPage(db),
+    saveWorkoutTemplate: (db, body) => saveMovementWorkoutTemplatePage(db, body.state),
+  },
+  undefined,
+  {
+    parseBody: async (request) => {
+      const parsed = movementRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid movement request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid movement request payload.', { status: 400 }),
+  }
+);

--- a/src/routes/api/movement/search-exercises/+server.ts
+++ b/src/routes/api/movement/search-exercises/+server.ts
@@ -1,17 +1,27 @@
 import type { ExerciseCatalogItem } from '$lib/core/domain/types';
 import { createDbQueryPostHandler } from '$lib/server/http/action-route';
+import {
+  movementQueryRequestSchema,
+  type MovementQueryRequest,
+} from '$lib/features/movement/contracts';
 import { upsertExerciseCatalogItems } from '$lib/features/movement/service';
 import { searchWgerExercises } from '$lib/server/movement/wger';
 
-type ExerciseSearchRequest = { query?: string };
-
-export const POST = createDbQueryPostHandler<ExerciseSearchRequest, ExerciseCatalogItem[]>(
+export const POST = createDbQueryPostHandler<MovementQueryRequest, ExerciseCatalogItem[]>(
   async (db, query) => {
     const results = await searchWgerExercises(query);
     return await upsertExerciseCatalogItems(db, results);
   },
   undefined,
   {
+    parseBody: async (request) => {
+      const parsed = movementQueryRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid exercise search request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid exercise search request payload.', { status: 400 }),
     emptyResult: [],
   }
 );

--- a/src/routes/api/nutrition/enrich/[fdcId]/+server.ts
+++ b/src/routes/api/nutrition/enrich/[fdcId]/+server.ts
@@ -1,4 +1,5 @@
 import { createDbPostHandler } from '$lib/server/http/action-route';
+import { nutritionEnrichParamsSchema } from '$lib/features/nutrition/contracts';
 import {
   foodLookupResultFromCatalogItem,
   type FoodLookupResult,
@@ -8,10 +9,11 @@ import { fetchUsdaFoodDetail, normalizeUsdaFoodDetail } from '$lib/server/nutrit
 
 export const POST = createDbPostHandler<void, FoodLookupResult>(
   async (db, _body, { params }) => {
-    const fdcId = params.fdcId;
-    if (!fdcId) {
-      throw new Error('USDA food id is required.');
+    const parsedParams = nutritionEnrichParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      throw new Error('Invalid USDA food id.');
     }
+    const { fdcId } = parsedParams.data;
 
     const apiKey = process.env.USDA_FDC_API_KEY ?? process.env.FDC_API_KEY;
     if (!apiKey) {
@@ -28,6 +30,9 @@ export const POST = createDbPostHandler<void, FoodLookupResult>(
     parseBody: async () => undefined,
     onActionError: (error) => {
       const message = error instanceof Error ? error.message : 'USDA enrich failed.';
+      if (message === 'Invalid USDA food id.') {
+        return new Response(message, { status: 400 });
+      }
       return new Response(message, { status: message.includes('not configured') ? 503 : 500 });
     },
   }

--- a/src/routes/api/nutrition/search-packaged/+server.ts
+++ b/src/routes/api/nutrition/search-packaged/+server.ts
@@ -1,5 +1,9 @@
 import { createDbQueryPostHandler } from '$lib/server/http/action-route';
 import {
+  nutritionQueryRequestSchema,
+  type NutritionQueryRequest,
+} from '$lib/features/nutrition/contracts';
+import {
   foodLookupResultFromCatalogItem,
   listFoodCatalogItems,
   searchPackagedFoodCatalog,
@@ -11,8 +15,6 @@ import {
   searchOpenFoodFactsProducts,
 } from '$lib/server/nutrition/open-food-facts';
 
-type PackagedSearchRequest = { query?: string };
-
 function dedupeLookupResults(items: FoodLookupResult[]): FoodLookupResult[] {
   const deduped = new Map<string, FoodLookupResult>();
   for (const item of items) {
@@ -21,7 +23,7 @@ function dedupeLookupResults(items: FoodLookupResult[]): FoodLookupResult[] {
   return [...deduped.values()];
 }
 
-export const POST = createDbQueryPostHandler<PackagedSearchRequest, FoodLookupResult[]>(
+export const POST = createDbQueryPostHandler<NutritionQueryRequest, FoodLookupResult[]>(
   async (db, query) => {
     const catalogItems = await listFoodCatalogItems(db);
     const localMatches = searchPackagedFoodCatalog(query, catalogItems);
@@ -39,6 +41,14 @@ export const POST = createDbQueryPostHandler<PackagedSearchRequest, FoodLookupRe
   },
   undefined,
   {
+    parseBody: async (request) => {
+      const parsed = nutritionQueryRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid packaged search request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid packaged search request payload.', { status: 400 }),
     emptyResult: [],
   }
 );

--- a/src/routes/api/nutrition/search-recipes/+server.ts
+++ b/src/routes/api/nutrition/search-recipes/+server.ts
@@ -1,9 +1,11 @@
 import type { RecipeCatalogItem } from '$lib/core/domain/types';
 import { createDbQueryPostHandler } from '$lib/server/http/action-route';
+import {
+  nutritionQueryRequestSchema,
+  type NutritionQueryRequest,
+} from '$lib/features/nutrition/contracts';
 import { listRecipeCatalogItems, upsertRecipeCatalogItem } from '$lib/features/nutrition/service';
 import { searchThemealdbRecipes } from '$lib/server/nutrition/themealdb';
-
-type RecipeSearchRequest = { query?: string };
 
 function dedupeRecipesById(items: RecipeCatalogItem[]): RecipeCatalogItem[] {
   const deduped = new Map<string, RecipeCatalogItem>();
@@ -13,7 +15,7 @@ function dedupeRecipesById(items: RecipeCatalogItem[]): RecipeCatalogItem[] {
   return [...deduped.values()];
 }
 
-export const POST = createDbQueryPostHandler<RecipeSearchRequest, RecipeCatalogItem[]>(
+export const POST = createDbQueryPostHandler<NutritionQueryRequest, RecipeCatalogItem[]>(
   async (db, query) => {
     const localMatches = (await listRecipeCatalogItems(db)).filter((recipe) =>
       recipe.title.toLowerCase().includes(query.toLowerCase())
@@ -27,6 +29,14 @@ export const POST = createDbQueryPostHandler<RecipeSearchRequest, RecipeCatalogI
   },
   undefined,
   {
+    parseBody: async (request) => {
+      const parsed = nutritionQueryRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid recipe search request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid recipe search request payload.', { status: 400 }),
     emptyResult: [],
   }
 );

--- a/src/routes/api/nutrition/search-usda/+server.ts
+++ b/src/routes/api/nutrition/search-usda/+server.ts
@@ -1,5 +1,9 @@
 import { createDbQueryPostHandler } from '$lib/server/http/action-route';
 import {
+  nutritionQueryRequestSchema,
+  type NutritionQueryRequest,
+} from '$lib/features/nutrition/contracts';
+import {
   listFoodCatalogItems,
   searchFoodData,
   searchLocalFoodCatalog,
@@ -12,8 +16,6 @@ type SearchUsdaResponse = {
   notice?: string;
 };
 
-type SearchUsdaRequest = { query?: string };
-
 function dedupeLookupResults(items: FoodLookupResult[]): FoodLookupResult[] {
   const deduped = new Map<string, FoodLookupResult>();
   for (const item of items) {
@@ -22,7 +24,7 @@ function dedupeLookupResults(items: FoodLookupResult[]): FoodLookupResult[] {
   return [...deduped.values()];
 }
 
-export const POST = createDbQueryPostHandler<SearchUsdaRequest, SearchUsdaResponse>(
+export const POST = createDbQueryPostHandler<NutritionQueryRequest, SearchUsdaResponse>(
   async (db, query) => {
     const catalogItems = await listFoodCatalogItems(db);
     const localMatches = searchLocalFoodCatalog(query, catalogItems);
@@ -43,6 +45,14 @@ export const POST = createDbQueryPostHandler<SearchUsdaRequest, SearchUsdaRespon
   },
   undefined,
   {
+    parseBody: async (request) => {
+      const parsed = nutritionQueryRequestSchema.safeParse(await request.json());
+      if (!parsed.success) {
+        throw new Error('Invalid USDA search request payload.');
+      }
+      return parsed.data;
+    },
+    onParseError: () => new Response('Invalid USDA search request payload.', { status: 400 }),
     emptyResult: { matches: [] },
   }
 );

--- a/tests/features/unit/movement/route.test.ts
+++ b/tests/features/unit/movement/route.test.ts
@@ -17,7 +17,7 @@ describe('movement route', () => {
     const loadMovementPage = vi.fn(async () => ({
       loading: false,
       saveNotice: '',
-      workoutTemplateForm: { title: '', goal: '', exerciseRefs: [] },
+      workoutTemplateForm: { title: '', goal: '', exercises: [] },
       workoutTemplates: [],
       exerciseCatalogItems: [{ id: 'wger:1', title: 'Goblet squat' }],
       exerciseSearchQuery: '',
@@ -31,12 +31,18 @@ describe('movement route', () => {
     vi.doMock('$lib/server/http/action-route', () => ({
       ...actual,
       createDbActionPostHandler: (
-        handlers: Parameters<typeof actual.createDbActionPostHandler>[0]
+        handlers: Parameters<typeof actual.createDbActionPostHandler>[0],
+        _deps: Parameters<typeof actual.createDbActionPostHandler>[1],
+        options: Parameters<typeof actual.createDbActionPostHandler>[2]
       ) =>
-        actual.createDbActionPostHandler(handlers, {
-          withDb: async (run) => await run(db),
-          toResponse: (body) => Response.json(body),
-        }),
+        actual.createDbActionPostHandler(
+          handlers,
+          {
+            withDb: async (run) => await run(db),
+            toResponse: (body) => Response.json(body),
+          },
+          options
+        ),
     }));
     vi.doMock('$lib/features/movement/controller', () => ({
       loadMovementPage,
@@ -69,7 +75,7 @@ describe('movement route', () => {
       workoutTemplateForm: {
         title: 'Full body reset',
         goal: 'Recovery',
-        exerciseRefs: [{ name: 'Goblet squat', sets: 3, reps: '8', restSeconds: 60 }],
+        exercises: [{ name: 'Goblet squat', sets: 3, reps: '8', restSeconds: 60 }],
       },
       workoutTemplates: [],
       exerciseCatalogItems: [],
@@ -89,12 +95,18 @@ describe('movement route', () => {
     vi.doMock('$lib/server/http/action-route', () => ({
       ...actual,
       createDbActionPostHandler: (
-        handlers: Parameters<typeof actual.createDbActionPostHandler>[0]
+        handlers: Parameters<typeof actual.createDbActionPostHandler>[0],
+        _deps: Parameters<typeof actual.createDbActionPostHandler>[1],
+        options: Parameters<typeof actual.createDbActionPostHandler>[2]
       ) =>
-        actual.createDbActionPostHandler(handlers, {
-          withDb: async (run) => await run(db),
-          toResponse: (body) => Response.json(body),
-        }),
+        actual.createDbActionPostHandler(
+          handlers,
+          {
+            withDb: async (run) => await run(db),
+            toResponse: (body) => Response.json(body),
+          },
+          options
+        ),
     }));
     vi.doMock('$lib/features/movement/controller', () => ({
       loadMovementPage,
@@ -118,6 +130,49 @@ describe('movement route', () => {
     );
     expect(saveMovementWorkoutTemplatePage).toHaveBeenCalledWith(db, state);
     expect(loadMovementPage).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid movement action payloads', async () => {
+    const db = {} as HealthDatabase;
+    const loadMovementPage = vi.fn();
+    const saveMovementWorkoutTemplatePage = vi.fn();
+    const actual = await vi.importActual<typeof import('$lib/server/http/action-route')>(
+      '$lib/server/http/action-route'
+    );
+
+    vi.doMock('$lib/server/http/action-route', () => ({
+      ...actual,
+      createDbActionPostHandler: (
+        handlers: Parameters<typeof actual.createDbActionPostHandler>[0],
+        _deps: Parameters<typeof actual.createDbActionPostHandler>[1],
+        options: Parameters<typeof actual.createDbActionPostHandler>[2]
+      ) =>
+        actual.createDbActionPostHandler(
+          handlers,
+          {
+            withDb: async (run) => await run(db),
+            toResponse: (body) => Response.json(body),
+          },
+          options
+        ),
+    }));
+    vi.doMock('$lib/features/movement/controller', () => ({
+      loadMovementPage,
+      saveMovementWorkoutTemplatePage,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/movement/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/movement', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'saveWorkoutTemplate' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid movement request payload.');
+    expect(loadMovementPage).not.toHaveBeenCalled();
+    expect(saveMovementWorkoutTemplatePage).not.toHaveBeenCalled();
   });
 });
 
@@ -191,5 +246,30 @@ describe('movement search route', () => {
     expect(searchWgerExercises).toHaveBeenCalledWith('goblet squat');
     expect(withServerHealthDb).toHaveBeenCalledOnce();
     expect(upsertExerciseCatalogItems).toHaveBeenCalledWith(db, results);
+  });
+
+  it('returns 400 for invalid exercise search payloads', async () => {
+    const searchWgerExercises = vi.fn();
+    const upsertExerciseCatalogItems = vi.fn();
+    const withServerHealthDb = vi.fn();
+
+    vi.doMock('$lib/server/movement/wger', () => ({ searchWgerExercises }));
+    vi.doMock('$lib/features/movement/service', () => ({ upsertExerciseCatalogItems }));
+    vi.doMock('$lib/server/db/client', () => ({ withServerHealthDb }));
+
+    const { POST } =
+      await import('../../../../src/routes/api/movement/search-exercises/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/movement/search-exercises', {
+        method: 'POST',
+        body: JSON.stringify({ query: 42 }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid exercise search request payload.');
+    expect(searchWgerExercises).not.toHaveBeenCalled();
+    expect(upsertExerciseCatalogItems).not.toHaveBeenCalled();
+    expect(withServerHealthDb).not.toHaveBeenCalled();
   });
 });

--- a/tests/features/unit/nutrition/route.test.ts
+++ b/tests/features/unit/nutrition/route.test.ts
@@ -135,6 +135,22 @@ describe('nutrition dynamic routes', () => {
     expect(upsertFoodCatalogItem).toHaveBeenCalledWith(db, normalizedProduct);
   });
 
+  it('returns 400 for invalid packaged search payloads', async () => {
+    await mockServerDb();
+
+    const { POST } =
+      await import('../../../../src/routes/api/nutrition/search-packaged/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/nutrition/search-packaged', {
+        method: 'POST',
+        body: JSON.stringify({ query: 42 }),
+      }),
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid packaged search request payload.');
+  });
+
   it('uses local USDA fallback search when no API key is present', async () => {
     const db = await mockServerDb();
     const catalogItems = [{ id: 'local-food-1', name: 'Oatmeal with berries' }];
@@ -171,6 +187,21 @@ describe('nutrition dynamic routes', () => {
     expect(searchUsdaFoods).not.toHaveBeenCalled();
   });
 
+  it('returns 400 for invalid USDA search payloads', async () => {
+    await mockServerDb();
+
+    const { POST } = await import('../../../../src/routes/api/nutrition/search-usda/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/nutrition/search-usda', {
+        method: 'POST',
+        body: JSON.stringify({ query: 42 }),
+      }),
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid USDA search request payload.');
+  });
+
   it('merges cached and remote recipe search results', async () => {
     const db = await mockServerDb();
     const localRecipe = { id: 'themealdb:52772', title: 'Teriyaki Chicken Casserole' };
@@ -203,5 +234,48 @@ describe('nutrition dynamic routes', () => {
     expect(listRecipeCatalogItems).toHaveBeenCalledWith(db);
     expect(searchThemealdbRecipes).toHaveBeenCalledWith('chicken');
     expect(upsertRecipeCatalogItem).toHaveBeenCalledWith(db, remoteRecipe);
+  });
+
+  it('returns 400 for invalid recipe search payloads', async () => {
+    await mockServerDb();
+
+    const { POST } = await import('../../../../src/routes/api/nutrition/search-recipes/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/nutrition/search-recipes', {
+        method: 'POST',
+        body: JSON.stringify({ query: 42 }),
+      }),
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid recipe search request payload.');
+  });
+
+  it('maps invalid USDA ids to a 400 enrich response', async () => {
+    await mockServerDb();
+    const fetchUsdaFoodDetail = vi.fn();
+    const normalizeUsdaFoodDetail = vi.fn();
+
+    vi.doMock('$lib/features/nutrition/service', () => ({
+      foodLookupResultFromCatalogItem: vi.fn(),
+      upsertFoodCatalogItem: vi.fn(),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail,
+      normalizeUsdaFoodDetail,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/nutrition/enrich/[fdcId]/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/nutrition/enrich/not-a-number', {
+        method: 'POST',
+      }),
+      params: { fdcId: 'not-a-number' },
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid USDA food id.');
+    expect(fetchUsdaFoodDetail).not.toHaveBeenCalled();
+    expect(normalizeUsdaFoodDetail).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add explicit request contracts for nutrition search and movement search/action endpoints
- return 400 for malformed search payloads and invalid USDA enrich ids instead of loose route behavior
- extend nutrition and movement route tests to lock the new parse-failure paths

## Verification
- bun run test:unit -- tests/features/unit/nutrition/route.test.ts tests/features/unit/movement/route.test.ts
- bun run check:ci

## Summary by Sourcery

Validate nutrition and movement API request payloads and tighten error handling for invalid inputs.

Bug Fixes:
- Ensure movement workout template requests validate the full page state, including exercises, before processing.
- Return HTTP 400 for invalid movement action and exercise search payloads instead of loosely handling malformed bodies.
- Return HTTP 400 for invalid nutrition search payloads and malformed USDA enrich ids, preventing undefined behavior in those routes.

Enhancements:
- Introduce shared Zod contracts for movement and nutrition query/request payloads to centralize validation logic.

Tests:
- Extend nutrition and movement route tests to cover parse-failure paths and 400 responses for invalid payloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict request validation to movement and nutrition search/action routes. Malformed bodies and non-numeric USDA IDs now return 400 with clear, route-specific messages, preventing unnecessary DB/API calls.

- **Bug Fixes**
  - Introduced Zod contracts for movement actions/search and nutrition query/enrich (`movementRequestSchema`, `movementQueryRequestSchema`, `nutritionQueryRequestSchema`, `nutritionEnrichParamsSchema`), including a custom guard for movement page state (`workoutTemplateForm.exercises`).
  - Wired parsing into `movement`, `movement/search-exercises`, `nutrition/search-packaged`, `nutrition/search-recipes`, and `nutrition/search-usda` POST handlers with 400 responses on parse errors.
  - Validated USDA `fdcId` in `nutrition/enrich/[fdcId]`; invalid IDs now return 400.
  - Extended unit tests to cover parse-failure paths and USDA ID errors, ensuring no DB/API calls occur on bad input.

<sup>Written for commit 891af5acd4e0b3d43adf9fb61b75e5468f193ab7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

