### PR TITLE
fix: upgrade aquasecurity/trivy-action to v0.35.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
           ls -la build/
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: 'build'


### PR DESCRIPTION
## Summary

Security fix for trivy-action supply chain attack (CVE).

- Upgrade `aquasecurity/trivy-action@0` → `aquasecurity/trivy-action@0.35.0`
- Version 0.35.0 is protected by GitHub's immutable releases feature

## Alert Details

The Trivy ecosystem was briefly compromised. Malicious code was injected via:
- Force-pushed tags to credential-stealing malware
- Compromised DockerHub images

Users of unpinned `@0` tag were exposed during the attack window.

## Fix

Pin to safe version `0.35.0` which is immutable and was not affected.

## Summary by Sourcery

CI:
- Update the Trivy vulnerability scanning step in the release workflow to use aquasecurity/trivy-action@0.35.0 instead of the floating @0 tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned Trivy GitHub Action to `aquasecurity/trivy-action@0.35.0` to mitigate the recent supply chain attack and use an immutable, safe release. This removes exposure from the unpinned `@0` tag.

- **Dependencies**
  - Upgrade `aquasecurity/trivy-action@0` → `aquasecurity/trivy-action@0.35.0` (immutable release protected by GitHub).

<sup>Written for commit 8476b06e4a99c52a2176ce0dda8f952d0fd7339b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

