### PR TITLE
Share grocery draft runtime across plan and groceries

### DIFF
--- a/src/lib/features/groceries/Page.svelte
+++ b/src/lib/features/groceries/Page.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { Button, Field, SectionCard } from '$lib/core/ui/primitives';
   import RoutePageHeader from '$lib/core/ui/shell/RoutePageHeader.svelte';
   import { onBrowserRouteMount } from '$lib/core/ui/route-runtime';
-  import GroceryChecklist from '$lib/features/groceries/components/GroceryChecklist.svelte';
-  import GroceryWarningsList from '$lib/features/groceries/components/GroceryWarningsList.svelte';
+  import GroceryDraftShell from '$lib/features/groceries/components/GroceryDraftShell.svelte';
   import {
     addManualGroceryItemPage,
+    createGroceryDraftState,
     createGroceriesPageState,
     loadGroceriesPage,
     removeManualGroceryItemPage,
@@ -13,31 +12,18 @@
   } from './client';
 
   let page = $state(createGroceriesPageState());
-  let manualLabel = $state('');
-  let manualQuantityText = $state('');
+  let draftState = $state(createGroceryDraftState());
 
   async function refreshData() {
     page = await loadGroceriesPage();
   }
 
-  async function toggleGrocery(
-    itemId: string,
-    checked: boolean,
-    excluded: boolean,
-    onHand: boolean
-  ) {
-    page = await toggleGroceryItemPage(page, itemId, { checked, excluded, onHand });
-  }
-
-  async function addManualItem() {
+  async function addManualItem(nextDraftState: typeof draftState) {
     page = await addManualGroceryItemPage(page, {
-      label: manualLabel,
-      quantityText: manualQuantityText,
+      label: nextDraftState.manualLabel,
+      quantityText: nextDraftState.manualQuantityText,
     });
-    if (page.saveNotice === 'Manual grocery item added.') {
-      manualLabel = '';
-      manualQuantityText = '';
-    }
+    return page.saveNotice === 'Manual grocery item added.';
   }
 
   async function removeManualItem(itemId: string) {
@@ -53,51 +39,28 @@
   <p class="status-copy">Loading groceries…</p>
 {:else}
   <div class="page-grid groceries-grid">
-    <SectionCard title="This week's grocery engine">
-      {#if page.weeklyPlan}
-        <p class="status-copy">{page.weeklyPlan.title} · week of {page.weeklyPlan.weekStart}</p>
-      {/if}
-      {#if page.saveNotice}
-        <p class="status-copy">{page.saveNotice}</p>
-      {/if}
-      <div class="manual-entry-grid">
-        <Field label="Manual grocery item">
-          <input bind:value={manualLabel} aria-label="Manual grocery item" />
-        </Field>
-        <Field label="Manual quantity">
-          <input bind:value={manualQuantityText} aria-label="Manual quantity" />
-        </Field>
-      </div>
-      <Button variant="secondary" onclick={addManualItem}>Add manual item</Button>
-      <GroceryWarningsList warnings={page.groceryWarnings} />
-    </SectionCard>
-
-    <SectionCard title="Checklist">
-      <GroceryChecklist
-        groceryItems={page.groceryItems}
-        groceryWarnings={page.groceryWarnings}
-        recipeCatalogItems={page.recipeCatalogItems}
-        emptyTitle="No grocery items yet."
-        emptyMessage="Plan at least one recipe this week and the grocery checklist will appear here."
-        emptyWarningMessage="No grocery items could be derived from the current recipe slots."
-        onToggleItem={(itemId, patch) =>
-          toggleGrocery(itemId, patch.checked, patch.excluded, patch.onHand)}
-        onRemoveManualItem={removeManualItem}
-      />
-    </SectionCard>
+    <GroceryDraftShell
+      title="This week's grocery engine"
+      shellState={page}
+      {draftState}
+      notice={page.saveNotice}
+      emptyTitle="No grocery items yet."
+      emptyMessage="Plan at least one recipe this week and the grocery checklist will appear here."
+      emptyWarningMessage="No grocery items could be derived from the current recipe slots."
+      onDraftStateChange={(nextDraftState) => {
+        draftState = nextDraftState;
+      }}
+      onAddManualItem={addManualItem}
+      onRemoveManualItem={removeManualItem}
+      onToggleItem={async (itemId, patch) => {
+        page = await toggleGroceryItemPage(page, itemId, patch);
+      }}
+    >
+      {#snippet header()}
+        {#if page.weeklyPlan}
+          <p class="status-copy">{page.weeklyPlan.title} · week of {page.weeklyPlan.weekStart}</p>
+        {/if}
+      {/snippet}
+    </GroceryDraftShell>
   </div>
 {/if}
-
-<style>
-  .manual-entry-grid {
-    display: grid;
-    gap: 0.75rem;
-    margin-block: 0.75rem;
-  }
-
-  @media (min-width: 720px) {
-    .manual-entry-grid {
-      grid-template-columns: minmax(0, 2fr) minmax(12rem, 1fr);
-    }
-  }
-</style>

--- a/src/lib/features/groceries/client.ts
+++ b/src/lib/features/groceries/client.ts
@@ -2,6 +2,7 @@ import { currentLocalDay } from '$lib/core/domain/time';
 import { createFeatureActionClient } from '$lib/core/http/feature-client';
 import {
   addManualGroceryItemPage as addManualGroceryItemPageController,
+  createGroceryDraftState,
   createGroceriesPageState,
   loadGroceriesPage as loadGroceriesPageController,
   removeManualGroceryItemPage as removeManualGroceryItemPageController,
@@ -10,7 +11,7 @@ import {
   type GroceriesPageState,
 } from './controller';
 
-export { createGroceriesPageState };
+export { createGroceryDraftState, createGroceriesPageState };
 
 const groceriesClient = createFeatureActionClient('/api/groceries');
 

--- a/src/lib/features/groceries/components/GroceryDraftShell.svelte
+++ b/src/lib/features/groceries/components/GroceryDraftShell.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { Button, Field, SectionCard } from '$lib/core/ui/primitives';
+  import type { GroceryItem, RecipeCatalogItem } from '$lib/core/domain/types';
+  import GroceryChecklist from './GroceryChecklist.svelte';
+  import GroceryWarningsList from './GroceryWarningsList.svelte';
+
+  type GroceryDraftShellState = {
+    groceryItems: GroceryItem[];
+    groceryWarnings: string[];
+    recipeCatalogItems: RecipeCatalogItem[];
+  };
+
+  type GroceryDraftState = {
+    manualLabel: string;
+    manualQuantityText: string;
+  };
+
+  let {
+    title,
+    shellState,
+    draftState,
+    notice,
+    emptyTitle,
+    emptyMessage,
+    emptyWarningMessage,
+    onDraftStateChange,
+    onAddManualItem,
+    onRemoveManualItem,
+    onToggleItem,
+    header,
+  }: {
+    title: string;
+    shellState: GroceryDraftShellState;
+    draftState: GroceryDraftState;
+    notice: string;
+    emptyTitle: string;
+    emptyMessage: string;
+    emptyWarningMessage: string;
+    onDraftStateChange: (nextDraftState: GroceryDraftState) => void;
+    onAddManualItem: (draftState: GroceryDraftState) => Promise<boolean> | boolean;
+    onRemoveManualItem: (itemId: string) => Promise<void> | void;
+    onToggleItem: (
+      itemId: string,
+      patch: Pick<GroceryItem, 'checked' | 'excluded' | 'onHand'>
+    ) => Promise<void> | void;
+    header?: Snippet;
+  } = $props();
+
+  function updateDraftState(nextDraftState: GroceryDraftState) {
+    onDraftStateChange(nextDraftState);
+  }
+
+  async function addManualItem() {
+    const shouldReset = await onAddManualItem(draftState);
+    if (shouldReset) {
+      updateDraftState({
+        manualLabel: '',
+        manualQuantityText: '',
+      });
+    }
+  }
+</script>
+
+<SectionCard {title}>
+  {@render header?.()}
+  {#if notice}
+    <p class="status-copy">{notice}</p>
+  {/if}
+  <div class="manual-entry-grid">
+    <Field label="Manual grocery item">
+      <input
+        value={draftState.manualLabel}
+        aria-label="Manual grocery item"
+        oninput={(event) =>
+          updateDraftState({
+            ...draftState,
+            manualLabel: (event.currentTarget as HTMLInputElement).value,
+          })}
+      />
+    </Field>
+    <Field label="Manual quantity">
+      <input
+        value={draftState.manualQuantityText}
+        aria-label="Manual quantity"
+        oninput={(event) =>
+          updateDraftState({
+            ...draftState,
+            manualQuantityText: (event.currentTarget as HTMLInputElement).value,
+          })}
+      />
+    </Field>
+  </div>
+  <Button variant="secondary" onclick={addManualItem}>Add manual item</Button>
+  <GroceryWarningsList warnings={shellState.groceryWarnings} />
+  <GroceryChecklist
+    groceryItems={shellState.groceryItems}
+    groceryWarnings={shellState.groceryWarnings}
+    recipeCatalogItems={shellState.recipeCatalogItems}
+    {emptyTitle}
+    {emptyMessage}
+    {emptyWarningMessage}
+    onToggleItem={(itemId, patch) => onToggleItem(itemId, patch)}
+    onRemoveManualItem={(itemId) => onRemoveManualItem(itemId)}
+  />
+</SectionCard>
+
+<style>
+  .manual-entry-grid {
+    display: grid;
+    gap: 0.75rem;
+    margin-block: 0.75rem;
+  }
+
+  @media (min-width: 720px) {
+    .manual-entry-grid {
+      grid-template-columns: minmax(0, 2fr) minmax(12rem, 1fr);
+    }
+  }
+</style>

--- a/src/lib/features/groceries/controller.ts
+++ b/src/lib/features/groceries/controller.ts
@@ -14,6 +14,11 @@ export interface ManualGroceryDraft {
   quantityText: string;
 }
 
+export interface GroceryDraftState {
+  manualLabel: string;
+  manualQuantityText: string;
+}
+
 export interface GroceriesPageState {
   loading: boolean;
   localDay: string;
@@ -33,6 +38,13 @@ export function createGroceriesPageState(): GroceriesPageState {
     groceryItems: [],
     groceryWarnings: [],
     recipeCatalogItems: [],
+  };
+}
+
+export function createGroceryDraftState(): GroceryDraftState {
+  return {
+    manualLabel: '',
+    manualQuantityText: '',
   };
 }
 

--- a/src/lib/features/planning/Page.svelte
+++ b/src/lib/features/planning/Page.svelte
@@ -5,6 +5,7 @@
   import WorkoutTemplateStudioShell from '$lib/features/movement/components/WorkoutTemplateStudioShell.svelte';
   import {
     addManualPlanningGroceryItemPage,
+    createGroceryDraftState,
     createPlanningPageState,
     deletePlanningSlotPage,
     loadPlanningPage,
@@ -22,8 +23,7 @@
 
   let page = $state(createPlanningPageState());
   let boardDays = $derived(createPlanningBoardDays(page.weekDays, page.slots));
-  let manualLabel = $state('');
-  let manualQuantityText = $state('');
+  let groceryDraftState = $state(createGroceryDraftState());
 
   async function refreshData() {
     page = await loadPlanningPage(undefined, page);
@@ -54,15 +54,12 @@
     page = await togglePlanningGroceryStatePage(page, itemId, { checked, excluded, onHand });
   }
 
-  async function addManualGroceryItem() {
+  async function addManualGroceryItem(nextDraftState: typeof groceryDraftState) {
     page = await addManualPlanningGroceryItemPage(page, {
-      label: manualLabel,
-      quantityText: manualQuantityText,
+      label: nextDraftState.manualLabel,
+      quantityText: nextDraftState.manualQuantityText,
     });
-    if (page.groceryNotice === 'Manual grocery item added.') {
-      manualLabel = '';
-      manualQuantityText = '';
-    }
+    return page.groceryNotice === 'Manual grocery item added.';
   }
 
   async function removeManualGroceryItem(itemId: string) {
@@ -151,13 +148,9 @@
       groceryWarnings={page.groceryWarnings}
       groceryItems={page.groceryItems}
       recipeCatalogItems={page.recipeCatalogItems}
-      {manualLabel}
-      {manualQuantityText}
-      onManualLabelChange={(value) => {
-        manualLabel = value;
-      }}
-      onManualQuantityChange={(value) => {
-        manualQuantityText = value;
+      draftState={groceryDraftState}
+      onDraftStateChange={(nextDraftState) => {
+        groceryDraftState = nextDraftState;
       }}
       onAddManualItem={addManualGroceryItem}
       onRemoveManualItem={removeManualGroceryItem}

--- a/src/lib/features/planning/client.ts
+++ b/src/lib/features/planning/client.ts
@@ -1,4 +1,5 @@
 import { currentLocalDay } from '$lib/core/domain/time';
+import { createGroceryDraftState } from '$lib/features/groceries/controller';
 import {
   createFeatureActionClient,
   createFeatureRequestClient,
@@ -24,7 +25,7 @@ import {
 } from './controller';
 import { searchExerciseCatalog } from '$lib/features/movement/service';
 
-export { createPlanningPageState };
+export { createGroceryDraftState, createPlanningPageState };
 
 const planningClient = createFeatureActionClient('/api/plan');
 const movementSearchClient = createFeatureRequestClient('/api/movement/search-exercises');

--- a/src/lib/features/planning/components/PlanningGroceryDraft.svelte
+++ b/src/lib/features/planning/components/PlanningGroceryDraft.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
-  import { Button, Field, SectionCard } from '$lib/core/ui/primitives';
+  import type { GroceryDraftState } from '$lib/features/groceries/controller';
   import type { GroceryItem, RecipeCatalogItem } from '$lib/core/domain/types';
-  import GroceryChecklist from '$lib/features/groceries/components/GroceryChecklist.svelte';
-  import GroceryWarningsList from '$lib/features/groceries/components/GroceryWarningsList.svelte';
+  import GroceryDraftShell from '$lib/features/groceries/components/GroceryDraftShell.svelte';
 
   let {
     groceryNotice,
     groceryWarnings,
     groceryItems,
     recipeCatalogItems,
-    manualLabel,
-    manualQuantityText,
-    onManualLabelChange,
-    onManualQuantityChange,
+    draftState,
+    onDraftStateChange,
     onAddManualItem,
     onRemoveManualItem,
     onToggleItem,
@@ -21,11 +18,9 @@
     groceryWarnings: string[];
     groceryItems: GroceryItem[];
     recipeCatalogItems: RecipeCatalogItem[];
-    manualLabel: string;
-    manualQuantityText: string;
-    onManualLabelChange: (value: string) => void;
-    onManualQuantityChange: (value: string) => void;
-    onAddManualItem: () => void;
+    draftState: GroceryDraftState;
+    onDraftStateChange: (nextDraftState: GroceryDraftState) => void;
+    onAddManualItem: (draftState: GroceryDraftState) => Promise<boolean>;
     onRemoveManualItem: (itemId: string) => void;
     onToggleItem: (
       itemId: string,
@@ -34,50 +29,20 @@
   } = $props();
 </script>
 
-<SectionCard title="Grocery draft">
-  {#if groceryNotice}
-    <p class="status-copy">{groceryNotice}</p>
-  {/if}
-  <div class="manual-entry-grid">
-    <Field label="Manual grocery item">
-      <input
-        value={manualLabel}
-        aria-label="Manual grocery item"
-        oninput={(event) => onManualLabelChange((event.currentTarget as HTMLInputElement).value)}
-      />
-    </Field>
-    <Field label="Manual quantity">
-      <input
-        value={manualQuantityText}
-        aria-label="Manual quantity"
-        oninput={(event) => onManualQuantityChange((event.currentTarget as HTMLInputElement).value)}
-      />
-    </Field>
-  </div>
-  <Button variant="secondary" onclick={onAddManualItem}>Add manual item</Button>
-  <GroceryWarningsList warnings={groceryWarnings} />
-  <GroceryChecklist
-    {groceryItems}
-    {groceryWarnings}
-    {recipeCatalogItems}
-    emptyTitle="No grocery items yet."
-    emptyMessage="Plan at least one recipe this week and the grocery draft will appear here."
-    emptyWarningMessage="No grocery items could be derived from the current recipe slots."
-    {onToggleItem}
-    {onRemoveManualItem}
-  />
-</SectionCard>
-
-<style>
-  .manual-entry-grid {
-    display: grid;
-    gap: 0.75rem;
-    margin-block: 0.75rem;
-  }
-
-  @media (min-width: 720px) {
-    .manual-entry-grid {
-      grid-template-columns: minmax(0, 2fr) minmax(12rem, 1fr);
-    }
-  }
-</style>
+<GroceryDraftShell
+  title="Grocery draft"
+  shellState={{
+    groceryItems,
+    groceryWarnings,
+    recipeCatalogItems,
+  }}
+  {draftState}
+  notice={groceryNotice}
+  emptyTitle="No grocery items yet."
+  emptyMessage="Plan at least one recipe this week and the grocery draft will appear here."
+  emptyWarningMessage="No grocery items could be derived from the current recipe slots."
+  {onDraftStateChange}
+  {onAddManualItem}
+  {onRemoveManualItem}
+  {onToggleItem}
+/>


### PR DESCRIPTION
## Summary
- add one shared grocery draft shell for manual item entry, warnings, and checklist rendering
- remove duplicate manual-grocery page wiring from both Groceries and Plan
- reuse the same draft-state factory across both surfaces instead of parallel local state

## Verification
- bun run test:unit -- tests/features/unit/groceries/client.test.ts tests/features/unit/groceries/controller.test.ts tests/features/unit/planning/controller.test.ts
- bun run test:component -- tests/features/component/groceries/GroceriesPage.spec.ts tests/features/component/planning/PlanPage.spec.ts
- bun run check:ci

## Summary by Sourcery

Extract grocery draft UI and state into a reusable shell shared between the groceries and planning pages, consolidating manual grocery item entry and checklist behavior.

Enhancements:
- Introduce a GroceryDraftShell component to encapsulate manual grocery entry, warnings, and checklist rendering for grocery-related views.
- Unify grocery draft local state via a shared GroceryDraftState factory used by both groceries and planning pages, removing duplicated manual-entry wiring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the grocery draft UI and runtime across Groceries and Planning using a shared shell and draft state. This removes duplicate manual-entry logic, keeps behavior consistent, and simplifies future changes.

- **Refactors**
  - Added `GroceryDraftShell.svelte` to handle manual item input, warnings, and checklist rendering.
  - Introduced `createGroceryDraftState` and exported it via `groceries/client` and `planning/client`.
  - Updated `groceries/Page.svelte`, `planning/components/PlanningGroceryDraft.svelte`, and `planning/Page.svelte` to use the shared shell and state; removed local manual-entry wiring.
  - Standardized draft updates via `onDraftStateChange`; `onAddManualItem` now returns a boolean to reset fields.
  - Moved duplicate layout styles into the shared shell.

<sup>Written for commit eba00084296d50c349a6619ba6f1b879f16b6999. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

