### PR TITLE
Add recovery-aware Today adaptation

### DIFF
--- a/src/lib/features/today/components/TodaySignalsSection.svelte
+++ b/src/lib/features/today/components/TodaySignalsSection.svelte
@@ -18,6 +18,25 @@
   } = $props();
 </script>
 
+{#if snapshot?.recoveryAdaptation}
+  <SectionCard title="Recovery today">
+    <p class="recovery-headline">{snapshot.recoveryAdaptation.headline}</p>
+    <ul class="nutrition-guidance-list">
+      {#each snapshot.recoveryAdaptation.reasons as line (line)}
+        <li>{line}</li>
+      {/each}
+    </ul>
+    <ul class="summary-list">
+      {#each snapshot.recoveryAdaptation.mealFallback as line (line)}
+        <li>{line}</li>
+      {/each}
+      {#each snapshot.recoveryAdaptation.workoutFallback as line (line)}
+        <li>{line}</li>
+      {/each}
+    </ul>
+  </SectionCard>
+{/if}
+
 <SectionCard title="Nutrition pulse">
   {#if snapshot}
     <div class="nutrition-pulse-grid">
@@ -69,6 +88,12 @@
 </SectionCard>
 
 <style>
+  .recovery-headline {
+    margin: 0 0 0.75rem;
+    color: #6b3d2b;
+    font-weight: 700;
+  }
+
   .nutrition-pulse-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));

--- a/src/lib/features/today/snapshot.ts
+++ b/src/lib/features/today/snapshot.ts
@@ -36,6 +36,14 @@ export interface TodayPlannedWorkout {
   status: PlanSlot['status'];
 }
 
+export interface TodayRecoveryAdaptation {
+  level: 'lighter-day' | 'recovery';
+  headline: string;
+  reasons: string[];
+  mealFallback: string[];
+  workoutFallback: string[];
+}
+
 export interface TodaySnapshot {
   date: string;
   dailyRecord: DailyRecord | null;
@@ -51,6 +59,7 @@ export interface TodaySnapshot {
   plannedMealIssue: string | null;
   plannedWorkout: TodayPlannedWorkout | null;
   plannedWorkoutIssue: string | null;
+  recoveryAdaptation: TodayRecoveryAdaptation | null;
   planItems: TodayPlanItem[];
   events: HealthEvent[];
   latestJournalEntry: JournalEntry | null;
@@ -128,6 +137,143 @@ function deriveTodayPlannedWorkoutIssue(
   return null;
 }
 
+function summarizeRecoveryReasons(
+  dailyRecord: DailyRecord | null,
+  events: HealthEvent[]
+): { level: TodayRecoveryAdaptation['level']; reasons: string[] } | null {
+  const recoveryReasons = new Set<string>();
+  const lighterReasons = new Set<string>();
+
+  const sleepHours = dailyRecord?.sleepHours;
+  if (typeof sleepHours === 'number') {
+    if (sleepHours < 6) {
+      recoveryReasons.add('Sleep landed under 6 hours.');
+    } else if (sleepHours < 7) {
+      lighterReasons.add('Sleep landed under 7 hours.');
+    }
+  }
+
+  const sleepQuality = dailyRecord?.sleepQuality;
+  if (typeof sleepQuality === 'number') {
+    if (sleepQuality <= 2) {
+      recoveryReasons.add('Sleep quality is dragging today.');
+    } else if (sleepQuality <= 3) {
+      lighterReasons.add('Sleep quality is softer than usual today.');
+    }
+  }
+
+  for (const event of events) {
+    if (event.eventType === 'symptom') {
+      const severity =
+        typeof event.payload?.severity === 'number'
+          ? event.payload.severity
+          : typeof event.value === 'number'
+            ? event.value
+            : null;
+      if (severity !== null) {
+        if (severity >= 4) {
+          recoveryReasons.add('Symptom load is elevated today.');
+        } else if (severity >= 3) {
+          lighterReasons.add('Symptoms are present enough to simplify the day.');
+        }
+      }
+    }
+
+    if (event.eventType === 'anxiety-episode') {
+      const intensity =
+        typeof event.payload?.intensity === 'number'
+          ? event.payload.intensity
+          : typeof event.value === 'number'
+            ? event.value
+            : null;
+      if (intensity !== null) {
+        if (intensity >= 7) {
+          recoveryReasons.add('Anxiety intensity spiked today.');
+        } else if (intensity >= 5) {
+          lighterReasons.add('Anxiety is elevated enough to lower friction.');
+        }
+      }
+    }
+  }
+
+  if (recoveryReasons.size) {
+    return {
+      level: 'recovery',
+      reasons: [...recoveryReasons],
+    };
+  }
+
+  if (lighterReasons.size) {
+    return {
+      level: 'lighter-day',
+      reasons: [...lighterReasons],
+    };
+  }
+
+  return null;
+}
+
+function buildRecoveryMealFallback(
+  plannedMeal: TodaySnapshot['plannedMeal'],
+  level: TodayRecoveryAdaptation['level']
+): string[] {
+  if (plannedMeal) {
+    return [
+      level === 'recovery'
+        ? 'Meal fallback: keep the next meal familiar, easy, and protein-forward.'
+        : `Meal fallback: keep ${plannedMeal.name} simple and skip any extra decision-making.`,
+    ];
+  }
+
+  return [
+    level === 'recovery'
+      ? 'Meal fallback: repeat one easy meal you already trust instead of improvising.'
+      : 'Meal fallback: pick one familiar meal and keep the rest of the day light.',
+  ];
+}
+
+function buildRecoveryWorkoutFallback(
+  plannedWorkout: TodayPlannedWorkout | null,
+  level: TodayRecoveryAdaptation['level']
+): string[] {
+  if (plannedWorkout) {
+    return [
+      level === 'recovery'
+        ? `Workout fallback: downgrade ${plannedWorkout.title} to a short walk, mobility reset, or full rest.`
+        : `Workout fallback: trim ${plannedWorkout.title} to the first block or swap to easy movement.`,
+    ];
+  }
+
+  return [
+    level === 'recovery'
+      ? 'Workout fallback: skip intensity today and protect recovery.'
+      : 'Workout fallback: keep movement gentle with a walk, mobility, or a short reset.',
+  ];
+}
+
+function deriveTodayRecoveryAdaptation(
+  dailyRecord: DailyRecord | null,
+  events: HealthEvent[],
+  plannedMeal: TodaySnapshot['plannedMeal'],
+  plannedWorkout: TodayPlannedWorkout | null
+): TodayRecoveryAdaptation | null {
+  const recoverySummary = summarizeRecoveryReasons(dailyRecord, events);
+  if (!recoverySummary) {
+    return null;
+  }
+
+  return {
+    level: recoverySummary.level,
+    headline:
+      recoverySummary.level === 'recovery'
+        ? 'Recovery mode: simplify the day.'
+        : 'Lighter day: reduce friction, not momentum.',
+    reasons: recoverySummary.reasons,
+    mealFallback: buildRecoveryMealFallback(plannedMeal, recoverySummary.level),
+    workoutFallback: buildRecoveryWorkoutFallback(plannedWorkout, recoverySummary.level),
+  };
+}
+
 export async function getTodayPlannedMealResolution(
   db: HealthDatabase,
   date: string
@@ -182,6 +328,12 @@ async function buildTodaySnapshotData(db: HealthDatabase, date: string): Promise
   const plannedWorkoutIssue = plannedWorkout
     ? null
     : deriveTodayPlannedWorkoutIssue(planSlots, workoutTemplates);
+  const recoveryAdaptation = deriveTodayRecoveryAdaptation(
+    dailyRecord ?? null,
+    events,
+    plannedMealResolution.candidate?.meal ?? null,
+    plannedWorkout
+  );
 
   return {
     date,
@@ -198,6 +350,7 @@ async function buildTodaySnapshotData(db: HealthDatabase, date: string): Promise
     plannedMealIssue: plannedMealResolution.issue,
     plannedWorkout,
     plannedWorkoutIssue,
+    recoveryAdaptation,
     planItems,
     events,
     latestJournalEntry,

--- a/tests/features/component/today/TodayPage.spec.ts
+++ b/tests/features/component/today/TodayPage.spec.ts
@@ -369,9 +369,7 @@ describe('Today route', () => {
       expect(screen.getByText('Symptom load is elevated today.')).toBeTruthy();
       expect(screen.getByText('Anxiety intensity spiked today.')).toBeTruthy();
       expect(
-        screen.getByText(
-          'Meal fallback: keep the next meal familiar, easy, and protein-forward.'
-        )
+        screen.getByText('Meal fallback: keep the next meal familiar, easy, and protein-forward.')
       ).toBeTruthy();
       expect(
         screen.getByText(

--- a/tests/features/component/today/TodayPage.spec.ts
+++ b/tests/features/component/today/TodayPage.spec.ts
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { getHealthDb } from '$lib/core/db/client';
 import { currentLocalDay } from '$lib/core/domain/time';
+import { logAnxietyEvent, logSymptomEvent } from '$lib/features/health/service';
 import { saveWorkoutTemplate } from '$lib/features/movement/service';
 import { saveFoodCatalogItem } from '$lib/features/nutrition/service';
 import { ensureWeeklyPlan, savePlanSlot } from '$lib/features/planning/service';
@@ -292,6 +293,89 @@ describe('Today route', () => {
       expect(
         screen.getByText(
           'That planned workout no longer exists. Replace it in Plan before using it today.'
+        )
+      ).toBeTruthy();
+    });
+  });
+
+  it('surfaces a recovery-aware fallback when sleep and symptoms are rough', async () => {
+    const db = getHealthDb();
+    const localDay = currentLocalDay();
+    const weeklyPlan = await ensureWeeklyPlan(db, localDay);
+    const food = await saveFoodCatalogItem(db, {
+      name: 'Greek yogurt bowl',
+      calories: 310,
+      protein: 24,
+      fiber: 6,
+      carbs: 34,
+      fat: 8,
+    });
+    const template = await saveWorkoutTemplate(db, {
+      title: 'Full body reset',
+      goal: 'Recovery',
+      exerciseRefs: [{ name: 'Goblet squat', reps: '8', sets: 3, restSeconds: 60 }],
+    });
+
+    await db.dailyRecords.put({
+      id: `daily:${localDay}`,
+      createdAt: '2026-04-02T08:00:00.000Z',
+      updatedAt: '2026-04-02T08:00:00.000Z',
+      date: localDay,
+      mood: 3,
+      energy: 2,
+      stress: 4,
+      focus: 3,
+      sleepHours: 5.5,
+      sleepQuality: 2,
+      freeformNote: 'Dragging today.',
+    });
+    await logSymptomEvent(db, {
+      localDay,
+      symptom: 'Headache',
+      severity: 4,
+      note: 'Heavy pressure behind the eyes.',
+    });
+    await logAnxietyEvent(db, {
+      localDay,
+      intensity: 7,
+      trigger: 'Cramped schedule',
+      durationMinutes: 25,
+    });
+    await savePlanSlot(db, {
+      weeklyPlanId: weeklyPlan.id,
+      localDay,
+      slotType: 'meal',
+      itemType: 'food',
+      itemId: food.id,
+      mealType: 'breakfast',
+      title: food.name,
+    });
+    await savePlanSlot(db, {
+      weeklyPlanId: weeklyPlan.id,
+      localDay,
+      slotType: 'workout',
+      itemType: 'workout-template',
+      itemId: template.id,
+      title: template.title,
+    });
+
+    render(TodayPage);
+    expectHeading('Today');
+
+    await waitFor(() => {
+      expect(screen.getByText('Recovery today')).toBeTruthy();
+      expect(screen.getByText('Recovery mode: simplify the day.')).toBeTruthy();
+      expect(screen.getByText('Sleep landed under 6 hours.')).toBeTruthy();
+      expect(screen.getByText('Symptom load is elevated today.')).toBeTruthy();
+      expect(screen.getByText('Anxiety intensity spiked today.')).toBeTruthy();
+      expect(
+        screen.getByText(
+          'Meal fallback: keep the next meal familiar, easy, and protein-forward.'
+        )
+      ).toBeTruthy();
+      expect(
+        screen.getByText(
+          'Workout fallback: downgrade Full body reset to a short walk, mobility reset, or full rest.'
         )
       ).toBeTruthy();
     });

--- a/tests/features/e2e/daily-flows.e2e.ts
+++ b/tests/features/e2e/daily-flows.e2e.ts
@@ -142,6 +142,172 @@ test('planned meal flows from nutrition into today logging', async ({ page }) =>
   await expect(page.getByText('Calories: 320')).toBeVisible();
 });
 
+test('today shows recovery-aware fallback when sleep and symptoms are rough', async ({ page }) => {
+  const localDay = new Intl.DateTimeFormat('en-CA', {
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+
+  const seedResponse = await page.request.post('/api/db/migrate', {
+    data: {
+      snapshot: {
+        dailyRecords: [
+          {
+            id: `daily:${localDay}`,
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            date: localDay,
+            mood: 3,
+            energy: 2,
+            stress: 4,
+            focus: 3,
+            sleepHours: 5.5,
+            sleepQuality: 2,
+            freeformNote: 'Dragging today.',
+          },
+        ],
+        journalEntries: [],
+        foodEntries: [],
+        foodCatalogItems: [
+          {
+            id: 'food-catalog-1',
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            name: 'Greek yogurt bowl',
+            sourceType: 'custom',
+            sourceName: 'Local catalog',
+            calories: 310,
+            protein: 24,
+            fiber: 6,
+            carbs: 34,
+            fat: 8,
+          },
+        ],
+        recipeCatalogItems: [],
+        weeklyPlans: [
+          {
+            id: 'weekly-plan-1',
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            weekStart: localDay,
+            title: `Week of ${localDay}`,
+          },
+        ],
+        planSlots: [
+          {
+            id: 'slot-meal-1',
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            weeklyPlanId: 'weekly-plan-1',
+            localDay,
+            slotType: 'meal',
+            itemType: 'food',
+            itemId: 'food-catalog-1',
+            mealType: 'breakfast',
+            title: 'Greek yogurt bowl',
+            status: 'planned',
+            order: 0,
+          },
+          {
+            id: 'slot-workout-1',
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            weeklyPlanId: 'weekly-plan-1',
+            localDay,
+            slotType: 'workout',
+            itemType: 'workout-template',
+            itemId: 'workout-template-1',
+            title: 'Full body reset',
+            status: 'planned',
+            order: 1,
+          },
+        ],
+        derivedGroceryItems: [],
+        manualGroceryItems: [],
+        workoutTemplates: [
+          {
+            id: 'workout-template-1',
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            title: 'Full body reset',
+            goal: 'Recovery',
+            exerciseRefs: [{ name: 'Goblet squat', reps: '8', sets: 3, restSeconds: 60 }],
+          },
+        ],
+        exerciseCatalogItems: [],
+        favoriteMeals: [],
+        healthEvents: [
+          {
+            id: 'symptom-1',
+            createdAt: '2026-04-02T09:00:00.000Z',
+            updatedAt: '2026-04-02T09:00:00.000Z',
+            sourceType: 'manual',
+            sourceApp: 'personal-health-cockpit',
+            sourceRecordId: 'symptom:1',
+            sourceTimestamp: '2026-04-02T09:00:00.000Z',
+            localDay,
+            timezone: 'UTC',
+            confidence: 1,
+            eventType: 'symptom',
+            value: 4,
+            payload: {
+              kind: 'symptom',
+              symptom: 'Headache',
+              severity: 4,
+              note: 'Heavy pressure behind the eyes.',
+            },
+          },
+          {
+            id: 'anxiety-1',
+            createdAt: '2026-04-02T10:00:00.000Z',
+            updatedAt: '2026-04-02T10:00:00.000Z',
+            sourceType: 'manual',
+            sourceApp: 'personal-health-cockpit',
+            sourceRecordId: 'anxiety:1',
+            sourceTimestamp: '2026-04-02T10:00:00.000Z',
+            localDay,
+            timezone: 'UTC',
+            confidence: 1,
+            eventType: 'anxiety-episode',
+            value: 7,
+            payload: {
+              kind: 'anxiety',
+              intensity: 7,
+              trigger: 'Cramped schedule',
+              durationMinutes: 25,
+            },
+          },
+        ],
+        healthTemplates: [],
+        sobrietyEvents: [],
+        assessmentResults: [],
+        importBatches: [],
+        importArtifacts: [],
+        reviewSnapshots: [],
+        adherenceMatches: [],
+      },
+    },
+  });
+  expect(seedResponse.ok()).toBe(true);
+
+  await page.goto('/today');
+  await expect(page.getByText('Recovery today')).toBeVisible();
+  await expect(page.getByText('Recovery mode: simplify the day.')).toBeVisible();
+  await expect(page.getByText('Sleep landed under 6 hours.')).toBeVisible();
+  await expect(page.getByText('Symptom load is elevated today.')).toBeVisible();
+  await expect(page.getByText('Anxiety intensity spiked today.')).toBeVisible();
+  await expect(
+    page.getByText('Meal fallback: keep the next meal familiar, easy, and protein-forward.')
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      'Workout fallback: downgrade Full body reset to a short walk, mobility reset, or full rest.'
+    )
+  ).toBeVisible();
+});
+
 test('weekly plan workout flows into today execution', async ({ page }) => {
   await page.goto('/plan');
   await page.getByLabel('Template name').fill('Full body reset');

--- a/tests/features/unit/today/model.test.ts
+++ b/tests/features/unit/today/model.test.ts
@@ -46,6 +46,7 @@ describe('today model', () => {
         status: 'planned',
       },
       plannedWorkoutIssue: null,
+      recoveryAdaptation: null,
       planItems: [],
       events: [],
       latestJournalEntry: null,

--- a/tests/features/unit/today/service.test.ts
+++ b/tests/features/unit/today/service.test.ts
@@ -4,6 +4,7 @@ import { saveDailyCheckin, getTodaySnapshot, listEventsForDay } from '$lib/featu
 import { ensureWeeklyPlan, savePlanSlot } from '$lib/features/planning/service';
 import { saveWorkoutTemplate } from '$lib/features/movement/service';
 import { saveFoodCatalogItem } from '$lib/features/nutrition/service';
+import { logAnxietyEvent, logSymptomEvent } from '$lib/features/health/service';
 import { useTestHealthDb } from '../../../support/unit/testDb';
 
 describe('today service', () => {
@@ -239,6 +240,80 @@ describe('today service', () => {
     expect(snapshot.plannedWorkout).toBeNull();
     expect(snapshot.plannedWorkoutIssue).toBe(
       'That planned workout no longer exists. Replace it in Plan before using it today.'
+    );
+  });
+
+  it('builds a recovery adaptation when sleep and strain point to a lighter day', async () => {
+    const db = getDb();
+    const weeklyPlan = await ensureWeeklyPlan(db, '2026-04-02');
+    const food = await saveFoodCatalogItem(db, {
+      name: 'Greek yogurt bowl',
+      calories: 310,
+      protein: 24,
+      fiber: 6,
+      carbs: 34,
+      fat: 8,
+    });
+    const workout = await saveWorkoutTemplate(db, {
+      title: 'Full body reset',
+      goal: 'Recovery',
+      exerciseRefs: [{ name: 'Goblet squat', reps: '8', sets: 3, restSeconds: 60 }],
+    });
+
+    await saveDailyCheckin(db, {
+      date: '2026-04-02',
+      mood: 3,
+      energy: 2,
+      stress: 4,
+      focus: 3,
+      sleepHours: 5.5,
+      sleepQuality: 2,
+      freeformNote: 'Dragging today.',
+    });
+    await logSymptomEvent(db, {
+      localDay: '2026-04-02',
+      symptom: 'Headache',
+      severity: 4,
+      note: 'Heavy pressure behind the eyes.',
+    });
+    await logAnxietyEvent(db, {
+      localDay: '2026-04-02',
+      intensity: 7,
+      trigger: 'Cramped schedule',
+      durationMinutes: 25,
+    });
+    await savePlanSlot(db, {
+      weeklyPlanId: weeklyPlan.id,
+      localDay: '2026-04-02',
+      slotType: 'meal',
+      itemType: 'food',
+      itemId: food.id,
+      title: food.name,
+      mealType: 'breakfast',
+    });
+    await savePlanSlot(db, {
+      weeklyPlanId: weeklyPlan.id,
+      localDay: '2026-04-02',
+      slotType: 'workout',
+      itemType: 'workout-template',
+      itemId: workout.id,
+      title: workout.title,
+    });
+
+    const snapshot = await getTodaySnapshot(db, '2026-04-02');
+
+    expect(snapshot.recoveryAdaptation).toMatchObject({
+      level: 'recovery',
+      headline: 'Recovery mode: simplify the day.',
+    });
+    expect(snapshot.recoveryAdaptation?.reasons).toContain('Sleep landed under 6 hours.');
+    expect(snapshot.recoveryAdaptation?.reasons).toContain('Symptom load is elevated today.');
+    expect(snapshot.recoveryAdaptation?.reasons).toContain('Anxiety intensity spiked today.');
+    expect(snapshot.recoveryAdaptation?.mealFallback).toContain(
+      'Meal fallback: keep the next meal familiar, easy, and protein-forward.'
+    );
+    expect(snapshot.recoveryAdaptation?.workoutFallback).toContain(
+      'Workout fallback: downgrade Full body reset to a short walk, mobility reset, or full rest.'
     );
   });
 });


### PR DESCRIPTION
Starts Phase 2 in the Today surface by deriving a recovery-aware daily adaptation state from sleep, symptom, and anxiety signals, then surfacing meal and workout fallback suggestions with unit, component, and focused E2E coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds recovery-aware adaptation to the Today page. We derive a daily “lighter-day” or “recovery” state from sleep, symptom, and anxiety signals, and show simple meal/workout fallbacks.

- **New Features**
  - Added `recoveryAdaptation` to the Today snapshot (level, headline, reasons, mealFallback, workoutFallback).
  - Render a "Recovery today" card in `TodaySignalsSection.svelte` with reasons plus meal/workout fallback guidance.
  - Tailor fallback text based on planned meal/workout presence and titles, with unit, component, and E2E coverage.

<sup>Written for commit 096f01bdcfb6448cf6afef0dd1cd0ace88eafceb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

