### PR TITLE
Hydrate linked context in Journal

### DIFF
--- a/src/lib/features/journal/Page.svelte
+++ b/src/lib/features/journal/Page.svelte
@@ -4,6 +4,7 @@
     beginJournalSave,
     createJournalPageState,
     deleteJournalPageEntry,
+    hydrateJournalIntent,
     loadJournalPage,
     saveJournalPage,
   } from '$lib/features/journal/client';
@@ -29,21 +30,7 @@
     }
 
     clearJournalIntentFromLocation(window.location, window.history);
-    page = {
-      ...loaded,
-      saveNotice:
-        intent.source === 'today-recovery'
-          ? 'Loaded from today recovery.'
-          : 'Loaded from review context.',
-      draft: {
-        ...loaded.draft,
-        localDay: intent.localDay,
-        entryType: intent.entryType,
-        title: intent.title,
-        body: intent.body,
-        linkedEventIds: intent.linkedEventIds,
-      },
-    };
+    page = await hydrateJournalIntent(loaded, intent);
   }
 
   async function handleSave() {
@@ -98,6 +85,19 @@
       {#if page.draft.linkedEventIds.length}
         <p class="status-copy">Linked context: {page.draft.linkedEventIds.length} events.</p>
       {/if}
+      {#if page.linkedContextRows.length}
+        <ul class="entry-list linked-context-list">
+          {#each page.linkedContextRows as row (row.id)}
+            <li>
+              <div>
+                <strong>{row.label}</strong>
+                <p>{row.valueLabel}</p>
+              </div>
+              <span class="status-copy">{row.sourceLabel}</span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
     </SectionCard>
 
     <SectionCard title="Today">
@@ -110,6 +110,9 @@
               <div>
                 <strong>{entry.title}</strong>
                 <p>{entry.body}</p>
+                {#if entry.contextLabel}
+                  <p class="status-copy">{entry.contextLabel}</p>
+                {/if}
               </div>
               <Button variant="ghost" onclick={() => handleDelete(entry.id)}>Delete</Button>
             </li>
@@ -139,6 +142,10 @@
   .entry-list p {
     margin: 0;
     color: #3a352e;
+  }
+
+  .linked-context-list {
+    margin-top: 0.85rem;
   }
 
   @media (min-width: 960px) {

--- a/src/lib/features/journal/client.ts
+++ b/src/lib/features/journal/client.ts
@@ -4,10 +4,12 @@ import {
   beginJournalSave,
   createJournalPageState,
   deleteJournalPageEntry as deleteJournalPageEntryController,
+  hydrateJournalIntentPage as hydrateJournalIntentPageController,
   loadJournalPage as loadJournalPageController,
   saveJournalPage as saveJournalPageController,
   type JournalPageState,
 } from './controller';
+import type { JournalIntent } from './navigation';
 
 export { beginJournalSave, createJournalPageState };
 
@@ -28,6 +30,18 @@ export async function loadJournalPage(
 export async function saveJournalPage(state: JournalPageState): Promise<JournalPageState> {
   return await journalClient.stateAction('save', state, (db) =>
     saveJournalPageController(db, state)
+  );
+}
+
+export async function hydrateJournalIntent(
+  state: JournalPageState,
+  intent: JournalIntent
+): Promise<JournalPageState> {
+  return await journalClient.stateAction(
+    'hydrateIntent',
+    state,
+    (db) => hydrateJournalIntentPageController(db, state, intent),
+    { intent }
   );
 }
 

--- a/src/lib/features/journal/controller.ts
+++ b/src/lib/features/journal/controller.ts
@@ -5,13 +5,19 @@ import {
   reloadLocalDayPageState,
 } from '$lib/core/shared/local-day-page';
 import type { JournalEntry } from '$lib/core/domain/types';
-import { createEmptyJournalDraft, normalizeJournalDraft } from './model';
+import {
+  createEmptyJournalDraft,
+  createJournalLinkedContextRows,
+  normalizeJournalDraft,
+  type JournalLinkedContextRow,
+} from './model';
 import {
   deleteJournalEntry,
   listJournalEntriesForDay,
   saveJournalEntry,
   type JournalDraft,
 } from '$lib/features/journal/service';
+import type { JournalIntent } from './navigation';
 
 export interface JournalPageState {
   loading: boolean;
@@ -20,6 +26,7 @@ export interface JournalPageState {
   saveNotice: string;
   entries: JournalEntry[];
   draft: JournalDraft;
+  linkedContextRows: JournalLinkedContextRow[];
 }
 
 export function createJournalPageState(): JournalPageState {
@@ -27,7 +34,16 @@ export function createJournalPageState(): JournalPageState {
     saving: false,
     entries: [],
     draft: createEmptyJournalDraft(''),
+    linkedContextRows: [],
   });
+}
+
+async function listLinkedJournalEvents(
+  db: HealthDatabase,
+  linkedEventIds: string[]
+): Promise<import('$lib/core/domain/types').HealthEvent[]> {
+  const events = await Promise.all(linkedEventIds.map((id) => db.healthEvents.get(id)));
+  return events.filter((event): event is NonNullable<typeof event> => Boolean(event));
 }
 
 export async function loadJournalPage(
@@ -44,6 +60,7 @@ export async function loadJournalPage(
       loading: false,
       localDay: nextLocalDay,
       entries,
+      linkedContextRows: [],
       draft: {
         ...current.draft,
         localDay: nextLocalDay,
@@ -85,6 +102,7 @@ export async function saveJournalPage(
     saving: false,
     saveNotice: saved.title ? `${saved.title} saved.` : 'Entry saved.',
     draft: createEmptyJournalDraft(state.localDay),
+    linkedContextRows: [],
   });
 }
 
@@ -95,4 +113,31 @@ export async function deleteJournalPageEntry(
 ): Promise<JournalPageState> {
   await deleteJournalEntry(db, id);
   return await refreshJournalEntries(db, state);
+}
+
+export async function hydrateJournalIntentPage(
+  db: HealthDatabase,
+  state: JournalPageState,
+  intent: JournalIntent
+): Promise<JournalPageState> {
+  const linkedEvents = await listLinkedJournalEvents(db, intent.linkedEventIds);
+
+  return {
+    ...state,
+    loading: false,
+    localDay: intent.localDay,
+    saveNotice:
+      intent.source === 'today-recovery'
+        ? 'Loaded from today recovery.'
+        : 'Loaded from review context.',
+    draft: {
+      ...state.draft,
+      localDay: intent.localDay,
+      entryType: intent.entryType,
+      title: intent.title,
+      body: intent.body,
+      linkedEventIds: [...intent.linkedEventIds],
+    },
+    linkedContextRows: createJournalLinkedContextRows(linkedEvents),
+  };
 }

--- a/src/lib/features/journal/model.ts
+++ b/src/lib/features/journal/model.ts
@@ -1,4 +1,5 @@
-import type { JournalEntry } from '$lib/core/domain/types';
+import type { HealthEvent, JournalEntry } from '$lib/core/domain/types';
+import { buildHealthEventDisplay } from '$lib/core/shared/health-events';
 import type { JournalDraft } from '$lib/features/journal/service';
 
 export const journalEntryTypeOptions = [
@@ -14,6 +15,14 @@ export type JournalEntryRow = {
   id: string;
   title: string;
   body: string;
+  contextLabel: string;
+};
+
+export type JournalLinkedContextRow = {
+  id: string;
+  label: string;
+  valueLabel: string;
+  sourceLabel: string;
 };
 
 export function createEmptyJournalDraft(localDay: string): JournalDraft {
@@ -43,5 +52,16 @@ export function createJournalEntryRows(entries: JournalEntry[]): JournalEntryRow
     id: entry.id,
     title: entry.title || 'Untitled entry',
     body: entry.body,
+    contextLabel:
+      entry.linkedEventIds.length > 0
+        ? `${entry.linkedEventIds.length} linked signal${entry.linkedEventIds.length === 1 ? '' : 's'}`
+        : '',
+  }));
+}
+
+export function createJournalLinkedContextRows(events: HealthEvent[]): JournalLinkedContextRow[] {
+  return events.map((event) => ({
+    id: event.id,
+    ...buildHealthEventDisplay(event),
   }));
 }

--- a/src/lib/features/review/analytics-shared.ts
+++ b/src/lib/features/review/analytics-shared.ts
@@ -49,7 +49,9 @@ export interface WeeklyReviewData {
   assessmentSummary: string[];
   healthHighlights: string[];
   contextSignals: string[];
+  contextCaptureLinkedEventIds: string[];
   journalHighlights: string[];
+  journalReflectionLinkedEventIds: string[];
   experimentOptions: string[];
 }
 

--- a/src/lib/features/review/model.ts
+++ b/src/lib/features/review/model.ts
@@ -53,6 +53,7 @@ function createReviewJournalIntentHref(
     entryType: 'evening_review' | 'symptom_note';
     title: string;
     body: string;
+    linkedEventIds: string[];
   }
 ): JournalIntentHref {
   return buildJournalIntentHref({
@@ -61,7 +62,7 @@ function createReviewJournalIntentHref(
     entryType: input.entryType,
     title: input.title,
     body: input.body,
-    linkedEventIds: [],
+    linkedEventIds: input.linkedEventIds,
   });
 }
 
@@ -185,6 +186,7 @@ export function createReviewSections(weekly: WeeklyReviewData | null): ReviewSec
                   '',
                   'What happened behind these signals? What should you watch next week?',
                 ].join('\n'),
+                linkedEventIds: weekly.contextCaptureLinkedEventIds,
               })
             : undefined,
         },
@@ -204,6 +206,7 @@ export function createReviewSections(weekly: WeeklyReviewData | null): ReviewSec
                   '',
                   'What felt true? What should you carry forward next week?',
                 ].join('\n'),
+                linkedEventIds: weekly.journalReflectionLinkedEventIds,
               })
             : undefined,
         },

--- a/src/lib/features/review/service.ts
+++ b/src/lib/features/review/service.ts
@@ -84,6 +84,7 @@ export async function buildWeeklySnapshot(
   const weekAssessments = filterByDays(assessments, (assessment) => assessment.localDay, days);
   const weekHealthEvents = filterByDays(healthEvents, (event) => event.localDay, days);
   const weekJournalEntries = filterByDays(journalEntries, (entry) => entry.localDay, days);
+  const journalDays = new Set(weekJournalEntries.map((entry) => entry.localDay));
   const weeklyPlan = weeklyPlans.find((plan) => plan.weekStart === weekStart) ?? null;
   const weekPlanSlots = weeklyPlan
     ? planSlots.filter((slot) => slot.weeklyPlanId === weeklyPlan.id)
@@ -141,7 +142,12 @@ export async function buildWeeklySnapshot(
     assessmentSummary: buildAssessmentSummary(weekAssessments),
     healthHighlights: buildHealthHighlights(weekRecords, weekHealthEvents),
     contextSignals: buildContextSignals(weekRecords, weekHealthEvents, weekJournalEntries),
+    contextCaptureLinkedEventIds: weekHealthEvents
+      .filter((event) => journalDays.has(event.localDay))
+      .map((event) => event.id)
+      .slice(0, 5),
     journalHighlights: buildJournalHighlights(weekJournalEntries),
+    journalReflectionLinkedEventIds: weekJournalEntries.flatMap((entry) => entry.linkedEventIds).slice(0, 5),
     experimentOptions: [...REVIEW_EXPERIMENT_OPTIONS],
   };
 }

--- a/src/routes/api/journal/+server.ts
+++ b/src/routes/api/journal/+server.ts
@@ -1,18 +1,22 @@
 import { createDbActionPostHandler } from '$lib/server/http/action-route';
 import {
   deleteJournalPageEntry,
+  hydrateJournalIntentPage,
   loadJournalPage,
   saveJournalPage,
   type JournalPageState,
 } from '$lib/features/journal/controller';
+import type { JournalIntent } from '$lib/features/journal/navigation';
 
 type JournalRequest =
   | { action: 'load'; localDay: string; state: JournalPageState }
+  | { action: 'hydrateIntent'; state: JournalPageState; intent: JournalIntent }
   | { action: 'save'; state: JournalPageState }
   | { action: 'delete'; state: JournalPageState; id: string };
 
 export const POST = createDbActionPostHandler<JournalRequest, JournalPageState>({
   load: (db, body) => loadJournalPage(db, body.localDay, body.state),
+  hydrateIntent: (db, body) => hydrateJournalIntentPage(db, body.state, body.intent),
   save: (db, body) => saveJournalPage(db, body.state),
   delete: (db, body) => deleteJournalPageEntry(db, body.state, body.id),
 });

--- a/tests/features/unit/journal/client.test.ts
+++ b/tests/features/unit/journal/client.test.ts
@@ -23,6 +23,7 @@ describe('journal client', () => {
     const state: ReturnType<typeof client.createJournalPageState> = {
       ...client.createJournalPageState(),
       localDay: '2026-04-04',
+      linkedContextRows: [],
       draft: {
         localDay: '2026-04-04',
         entryType: 'freeform',
@@ -34,6 +35,14 @@ describe('journal client', () => {
     };
 
     await client.loadJournalPage(state, '2026-04-04');
+    await client.hydrateJournalIntent(state, {
+      source: 'today-recovery',
+      localDay: '2026-04-04',
+      entryType: 'symptom_note',
+      title: 'Recovery note',
+      body: 'Crowded store and headache drained the afternoon.',
+      linkedEventIds: ['symptom-1', 'anxiety-1'],
+    });
     await client.saveJournalPage(state);
     await client.deleteJournalPageEntry(state, 'journal-entry-1');
 
@@ -41,8 +50,18 @@ describe('journal client', () => {
     expect(stateAction).toHaveBeenNthCalledWith(1, 'load', state, expect.any(Function), {
       localDay: '2026-04-04',
     });
-    expect(stateAction).toHaveBeenNthCalledWith(2, 'save', state, expect.any(Function));
-    expect(stateAction).toHaveBeenNthCalledWith(3, 'delete', state, expect.any(Function), {
+    expect(stateAction).toHaveBeenNthCalledWith(2, 'hydrateIntent', state, expect.any(Function), {
+      intent: {
+        source: 'today-recovery',
+        localDay: '2026-04-04',
+        entryType: 'symptom_note',
+        title: 'Recovery note',
+        body: 'Crowded store and headache drained the afternoon.',
+        linkedEventIds: ['symptom-1', 'anxiety-1'],
+      },
+    });
+    expect(stateAction).toHaveBeenNthCalledWith(3, 'save', state, expect.any(Function));
+    expect(stateAction).toHaveBeenNthCalledWith(4, 'delete', state, expect.any(Function), {
       id: 'journal-entry-1',
     });
     expect(action).not.toHaveBeenCalled();

--- a/tests/features/unit/journal/controller.test.ts
+++ b/tests/features/unit/journal/controller.test.ts
@@ -4,6 +4,7 @@ import {
   beginJournalSave,
   createJournalPageState,
   deleteJournalPageEntry,
+  hydrateJournalIntentPage,
   loadJournalPage,
   saveJournalPage,
 } from '$lib/features/journal/controller';
@@ -30,5 +31,48 @@ describe('journal controller', () => {
 
     state = await deleteJournalPageEntry(db, state, state.entries[0]!.id);
     expect(state.entries).toEqual([]);
+  });
+
+  it('hydrates a journal intent with linked context rows', async () => {
+    const db = getDb();
+    await db.healthEvents.put({
+      id: 'symptom-1',
+      createdAt: '2026-04-04T09:00:00.000Z',
+      updatedAt: '2026-04-04T09:00:00.000Z',
+      sourceType: 'manual',
+      sourceApp: 'personal-health-cockpit',
+      sourceRecordId: 'symptom:1',
+      sourceTimestamp: '2026-04-04T09:00:00.000Z',
+      localDay: '2026-04-04',
+      timezone: 'UTC',
+      confidence: 1,
+      eventType: 'symptom',
+      value: 4,
+      payload: {
+        kind: 'symptom',
+        symptom: 'Headache',
+        severity: 4,
+      },
+    });
+
+    const loaded = await loadJournalPage(db, '2026-04-04', createJournalPageState());
+    const state = await hydrateJournalIntentPage(db, loaded, {
+      source: 'today-recovery',
+      localDay: '2026-04-04',
+      entryType: 'symptom_note',
+      title: 'Recovery note',
+      body: 'Crowded store and headache drained the afternoon.',
+      linkedEventIds: ['symptom-1'],
+    });
+
+    expect(state.saveNotice).toBe('Loaded from today recovery.');
+    expect(state.draft.title).toBe('Recovery note');
+    expect(state.linkedContextRows).toEqual([
+      expect.objectContaining({
+        id: 'symptom-1',
+        label: 'Symptom',
+        valueLabel: '4',
+      }),
+    ]);
   });
 });

--- a/tests/features/unit/journal/model.test.ts
+++ b/tests/features/unit/journal/model.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { JournalEntry } from '$lib/core/domain/types';
+import type { HealthEvent, JournalEntry } from '$lib/core/domain/types';
 import {
   createEmptyJournalDraft,
   createJournalEntryRows,
+  createJournalLinkedContextRows,
   normalizeJournalDraft,
 } from '$lib/features/journal/model';
 
@@ -28,12 +29,38 @@ describe('journal model', () => {
         entryType: 'freeform',
         body: 'Woke up steady.',
         tags: [],
-        linkedEventIds: [],
+        linkedEventIds: ['manual:2026-04-02:mood'],
       } satisfies JournalEntry,
+    ]);
+    const linkedRows = createJournalLinkedContextRows([
+      {
+        id: 'symptom-1',
+        createdAt: '2026-04-02T09:00:00.000Z',
+        updatedAt: '2026-04-02T09:00:00.000Z',
+        sourceType: 'manual',
+        sourceApp: 'personal-health-cockpit',
+        sourceRecordId: 'symptom:1',
+        sourceTimestamp: '2026-04-02T09:00:00.000Z',
+        localDay: '2026-04-02',
+        timezone: 'UTC',
+        confidence: 1,
+        eventType: 'symptom',
+        value: 4,
+        payload: {
+          kind: 'symptom',
+          symptom: 'Headache',
+          severity: 4,
+        },
+      } satisfies HealthEvent,
     ]);
 
     expect(normalized.title).toBe('Morning check-in');
     expect(normalized.body).toBe('Woke up steady.');
     expect(rows[0]?.title).toBe('Untitled entry');
+    expect(rows[0]?.contextLabel).toBe('1 linked signal');
+    expect(linkedRows[0]).toMatchObject({
+      label: 'Symptom',
+      valueLabel: '4',
+    });
   });
 });

--- a/tests/features/unit/journal/route.test.ts
+++ b/tests/features/unit/journal/route.test.ts
@@ -12,6 +12,7 @@ describe('journal route', () => {
   async function importRoute(overrides: {
     db?: HealthDatabase;
     loadJournalPage?: ReturnType<typeof vi.fn>;
+    hydrateJournalIntentPage?: ReturnType<typeof vi.fn>;
     saveJournalPage?: ReturnType<typeof vi.fn>;
     deleteJournalPageEntry?: ReturnType<typeof vi.fn>;
   }) {
@@ -39,6 +40,7 @@ describe('journal route', () => {
           localDay: '2026-04-04',
           saveNotice: '',
           entries: [],
+          linkedContextRows: [],
           draft: {
             localDay: '2026-04-04',
             entryType: 'freeform',
@@ -53,6 +55,12 @@ describe('journal route', () => {
         vi.fn(async (_db: HealthDatabase, state: unknown) => ({
           ...(state as object),
           saveNotice: 'Entry saved.',
+        })),
+      hydrateJournalIntentPage:
+        overrides.hydrateJournalIntentPage ??
+        vi.fn(async (_db: HealthDatabase, state: unknown) => ({
+          ...(state as object),
+          saveNotice: 'Loaded from today recovery.',
         })),
       deleteJournalPageEntry:
         overrides.deleteJournalPageEntry ??
@@ -90,6 +98,7 @@ describe('journal route', () => {
       localDay: '',
       saveNotice: '',
       entries: [],
+      linkedContextRows: [],
       draft: {
         localDay: '',
         entryType: 'freeform',
@@ -124,6 +133,7 @@ describe('journal route', () => {
       localDay: '2026-04-04',
       saveNotice: '',
       entries: [],
+      linkedContextRows: [],
       draft: {
         localDay: '2026-04-04',
         entryType: 'freeform',
@@ -162,5 +172,59 @@ describe('journal route', () => {
     } as Parameters<typeof POST>[0]);
     expect(await deleteResponse.json()).toEqual(expect.objectContaining({ entries: [] }));
     expect(deleteJournalPageEntry).toHaveBeenCalledWith(db, state, 'journal-entry-1');
+  });
+
+  it('dispatches journal intent hydration through the action route', async () => {
+    const db = {} as HealthDatabase;
+    const state = {
+      loading: false,
+      saving: false,
+      localDay: '2026-04-04',
+      saveNotice: '',
+      entries: [],
+      draft: {
+        localDay: '2026-04-04',
+        entryType: 'freeform',
+        title: '',
+        body: '',
+        tags: [],
+        linkedEventIds: [],
+      },
+    };
+    const hydrateJournalIntentPage = vi.fn(async () => ({
+      ...state,
+      saveNotice: 'Loaded from today recovery.',
+    }));
+    const { POST } = await importRoute({ db, hydrateJournalIntentPage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/journal', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'hydrateIntent',
+          state,
+          intent: {
+            source: 'today-recovery',
+            localDay: '2026-04-04',
+            entryType: 'symptom_note',
+            title: 'Recovery note',
+            body: 'Crowded store and headache drained the afternoon.',
+            linkedEventIds: ['symptom-1', 'anxiety-1'],
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(await response.json()).toEqual(
+      expect.objectContaining({ saveNotice: 'Loaded from today recovery.' })
+    );
+    expect(hydrateJournalIntentPage).toHaveBeenCalledWith(db, state, {
+      source: 'today-recovery',
+      localDay: '2026-04-04',
+      entryType: 'symptom_note',
+      title: 'Recovery note',
+      body: 'Crowded store and headache drained the afternoon.',
+      linkedEventIds: ['symptom-1', 'anxiety-1'],
+    });
   });
 });

--- a/tests/features/unit/review/model.test.ts
+++ b/tests/features/unit/review/model.test.ts
@@ -96,9 +96,11 @@ describe('review model', () => {
       assessmentSummary: ['WHO-5: Strong wellbeing (17)'],
       healthHighlights: [],
       contextSignals: ['Low sleep and a written reflection both landed on 2026-04-02.'],
+      contextCaptureLinkedEventIds: ['anxiety-1'],
       journalHighlights: [
         'Evening review on 2026-04-02: Crowded store and headache drained the afternoon.',
       ],
+      journalReflectionLinkedEventIds: ['anxiety-1'],
       experimentOptions: ['Increase hydration tracking'],
     };
 
@@ -185,9 +187,11 @@ describe('review model', () => {
       assessmentSummary: [],
       healthHighlights: ['Low sleep lined up with higher anxiety on 2026-04-02.'],
       contextSignals: ['Low sleep and a written reflection both landed on 2026-04-02.'],
+      contextCaptureLinkedEventIds: ['anxiety-1'],
       journalHighlights: [
         'Evening review on 2026-04-02: Crowded store and headache drained the afternoon.',
       ],
+      journalReflectionLinkedEventIds: ['anxiety-1'],
       experimentOptions: ['Increase hydration tracking'],
     };
 


### PR DESCRIPTION
Continues Phase 3 by making linked context real inside Journal. Today and Review intents now hydrate the Journal draft through an explicit controller/route action, show linked event previews in the composer, and preserve linked-signal counts on saved entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Journal now hydrates linked context when navigating from Today or Review, showing linked event previews in the composer and preserving linked-signal counts after save. Adds a server/controller action to hydrate intents and passes linked event IDs from Review.

- **New Features**
  - Controller: added `hydrateJournalIntentPage` to build the draft and `linkedContextRows` from intent-linked `HealthEvent`s; API route now handles `hydrateIntent`.
  - Client: added `hydrateJournalIntent(state, intent)` to invoke the server hydration action.
  - UI: shows linked context previews in the composer and a “linked signal(s)” label on entry rows.
  - Model: added `JournalLinkedContextRow` and `createJournalLinkedContextRows` (via `buildHealthEventDisplay`).
  - Review: weekly snapshot now exposes `contextCaptureLinkedEventIds` and `journalReflectionLinkedEventIds`; review model passes these into journal intents.

<sup>Written for commit dd967a2447348cc14c08ed053ff1d71df14ee448. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

