### PR TITLE
Add repeated context patterns to review

### DIFF
--- a/src/lib/features/review/analytics-health.ts
+++ b/src/lib/features/review/analytics-health.ts
@@ -129,10 +129,7 @@ export function buildContextSignals(
   return [...new Set(signals)];
 }
 
-export function buildPatternHighlights(
-  entries: JournalEntry[],
-  events: HealthEvent[]
-): string[] {
+export function buildPatternHighlights(entries: JournalEntry[], events: HealthEvent[]): string[] {
   const highlights: string[] = [];
   const eventsById = new Map(events.map((event) => [event.id, event]));
 
@@ -175,12 +172,16 @@ export function buildPatternHighlights(
 
   for (const [symptomName, days] of symptomDaysByName) {
     if (days.size >= 2) {
-      highlights.push(`${symptomName} kept showing up in your notes on ${days.size} days this week.`);
+      highlights.push(
+        `${symptomName} kept showing up in your notes on ${days.size} days this week.`
+      );
     }
   }
 
   if (anxietyDays.size >= 2) {
-    highlights.push(`Anxiety-related context showed up in your notes on ${anxietyDays.size} days this week.`);
+    highlights.push(
+      `Anxiety-related context showed up in your notes on ${anxietyDays.size} days this week.`
+    );
   }
 
   return highlights;

--- a/src/lib/features/review/analytics-health.ts
+++ b/src/lib/features/review/analytics-health.ts
@@ -128,3 +128,60 @@ export function buildContextSignals(
 
   return [...new Set(signals)];
 }
+
+export function buildPatternHighlights(
+  entries: JournalEntry[],
+  events: HealthEvent[]
+): string[] {
+  const highlights: string[] = [];
+  const eventsById = new Map(events.map((event) => [event.id, event]));
+
+  const symptomDaysByName = new Map<string, Set<string>>();
+  const anxietyDays = new Set<string>();
+
+  for (const entry of entries) {
+    const seenSymptomNames = new Set<string>();
+    let linkedAnxiety = false;
+
+    for (const eventId of entry.linkedEventIds) {
+      const event = eventsById.get(eventId);
+      if (!event) {
+        continue;
+      }
+
+      if (event.eventType === 'symptom') {
+        const symptomName =
+          typeof event.payload?.symptom === 'string'
+            ? event.payload.symptom.trim()
+            : 'Symptom';
+        if (!seenSymptomNames.has(symptomName)) {
+          seenSymptomNames.add(symptomName);
+          if (!symptomDaysByName.has(symptomName)) {
+            symptomDaysByName.set(symptomName, new Set());
+          }
+          symptomDaysByName.get(symptomName)!.add(entry.localDay);
+        }
+      }
+
+      if (event.eventType === 'anxiety-episode') {
+        linkedAnxiety = true;
+      }
+    }
+
+    if (linkedAnxiety) {
+      anxietyDays.add(entry.localDay);
+    }
+  }
+
+  for (const [symptomName, days] of symptomDaysByName) {
+    if (days.size >= 2) {
+      highlights.push(`${symptomName} kept showing up in your notes on ${days.size} days this week.`);
+    }
+  }
+
+  if (anxietyDays.size >= 2) {
+    highlights.push(`Anxiety-related context showed up in your notes on ${anxietyDays.size} days this week.`);
+  }
+
+  return highlights;
+}

--- a/src/lib/features/review/analytics-health.ts
+++ b/src/lib/features/review/analytics-health.ts
@@ -151,7 +151,7 @@ export function buildPatternHighlights(
 
       if (event.eventType === 'symptom') {
         const symptomName =
-          typeof event.payload?.symptom === 'string'
+          typeof event.payload?.symptom === 'string' && event.payload.symptom.trim().length > 0
             ? event.payload.symptom.trim()
             : 'Symptom';
         if (!seenSymptomNames.has(symptomName)) {

--- a/src/lib/features/review/analytics-shared.ts
+++ b/src/lib/features/review/analytics-shared.ts
@@ -52,6 +52,7 @@ export interface WeeklyReviewData {
   contextCaptureLinkedEventIds: string[];
   journalHighlights: string[];
   journalReflectionLinkedEventIds: string[];
+  patternHighlights: string[];
   experimentOptions: string[];
 }
 

--- a/src/lib/features/review/analytics.ts
+++ b/src/lib/features/review/analytics.ts
@@ -28,4 +28,5 @@ export {
   buildDeviceHighlights,
   buildHealthHighlights,
   buildJournalHighlights,
+  buildPatternHighlights,
 } from './analytics-health';

--- a/src/lib/features/review/model.ts
+++ b/src/lib/features/review/model.ts
@@ -211,6 +211,12 @@ export function createReviewSections(weekly: WeeklyReviewData | null): ReviewSec
             : undefined,
         },
         {
+          title: 'Patterns to watch',
+          items: weekly.patternHighlights,
+          emptyMessage:
+            'Repeat a few linked context notes before Review can surface recurring patterns.',
+        },
+        {
           title: 'Food adherence highlights',
           items: weekly.nutritionHighlights,
           emptyMessage: 'Nutrition needs a few more logged meals before highlights mean much.',

--- a/src/lib/features/review/service.ts
+++ b/src/lib/features/review/service.ts
@@ -15,6 +15,7 @@ import {
   buildHealthHighlights,
   buildHeadline,
   buildJournalHighlights,
+  buildPatternHighlights,
   buildNutritionHighlights,
   buildNutritionStrategy,
   buildPlanningHighlights,
@@ -150,6 +151,7 @@ export async function buildWeeklySnapshot(
     journalReflectionLinkedEventIds: weekJournalEntries
       .flatMap((entry) => entry.linkedEventIds)
       .slice(0, 5),
+    patternHighlights: buildPatternHighlights(weekJournalEntries, weekHealthEvents),
     experimentOptions: [...REVIEW_EXPERIMENT_OPTIONS],
   };
 }

--- a/tests/features/component/review/ReviewPage.spec.ts
+++ b/tests/features/component/review/ReviewPage.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetRouteDb, expectHeading, waitForText } from '../../../support/component/routeHarness';
 import { seedReviewSnapshotInputs } from '../../../support/component/routeSeeds';
 import { getHealthDb } from '$lib/core/db/client';
+import { logAnxietyEvent, logSymptomEvent } from '$lib/features/health/service';
 import { saveJournalEntry } from '$lib/features/journal/service';
 import { createFoodEntry, saveFoodCatalogItem } from '$lib/features/nutrition/service';
 import { ensureWeeklyPlan, savePlanSlot } from '$lib/features/planning/service';
@@ -194,5 +195,53 @@ describe('Review route', () => {
     expect(screen.getByRole('link', { name: 'Write reflection' }).getAttribute('href')).toMatch(
       /^\/journal\?/
     );
+  });
+
+  it('shows repeated context patterns inside review', async () => {
+    await seedReviewSnapshotInputs();
+    const db = getHealthDb();
+    const symptomOne = await logSymptomEvent(db, {
+      localDay: '2026-03-30',
+      symptom: 'Headache',
+      severity: 4,
+    });
+    const symptomTwo = await logSymptomEvent(db, {
+      localDay: '2026-03-31',
+      symptom: 'Headache',
+      severity: 4,
+    });
+    const anxietyOne = await logAnxietyEvent(db, {
+      localDay: '2026-03-30',
+      intensity: 6,
+      trigger: 'Crowded store',
+    });
+    const anxietyTwo = await logAnxietyEvent(db, {
+      localDay: '2026-03-31',
+      intensity: 6,
+      trigger: 'Cramped schedule',
+    });
+    await saveJournalEntry(db, {
+      localDay: '2026-03-30',
+      entryType: 'symptom_note',
+      title: 'Headache note',
+      body: 'Headache and worry hit after lunch.',
+      tags: [],
+      linkedEventIds: [symptomOne.id, anxietyOne.id],
+    });
+    await saveJournalEntry(db, {
+      localDay: '2026-03-31',
+      entryType: 'symptom_note',
+      title: 'Headache note',
+      body: 'Headache and worry hit again after errands.',
+      tags: [],
+      linkedEventIds: [symptomTwo.id, anxietyTwo.id],
+    });
+
+    render(ReviewPage);
+    expectHeading('Review');
+
+    await waitForText('Patterns to watch');
+    await waitForText(/Headache kept showing up in your notes on 2 days this week\./i);
+    await waitForText(/Anxiety-related context showed up in your notes on 2 days this week\./i);
   });
 });

--- a/tests/features/e2e/daily-flows.e2e.ts
+++ b/tests/features/e2e/daily-flows.e2e.ts
@@ -232,6 +232,166 @@ test('weekly review surfaces journal context signals', async ({ page }) => {
   ).toBeVisible();
 });
 
+test('weekly review surfaces repeated context patterns', async ({ page }) => {
+  const seedResponse = await page.request.post('/api/db/migrate', {
+    data: {
+      snapshot: {
+        dailyRecords: [
+          {
+            id: 'daily:2026-03-30',
+            createdAt: '2026-03-30T08:00:00.000Z',
+            updatedAt: '2026-03-30T08:00:00.000Z',
+            date: '2026-03-30',
+            mood: 3,
+            energy: 2,
+            stress: 3,
+            focus: 3,
+            sleepHours: 6,
+            sleepQuality: 3,
+          },
+          {
+            id: 'daily:2026-03-31',
+            createdAt: '2026-03-31T08:00:00.000Z',
+            updatedAt: '2026-03-31T08:00:00.000Z',
+            date: '2026-03-31',
+            mood: 3,
+            energy: 2,
+            stress: 3,
+            focus: 3,
+            sleepHours: 6,
+            sleepQuality: 3,
+          },
+        ],
+        journalEntries: [
+          {
+            id: 'journal-1',
+            createdAt: '2026-03-30T21:00:00.000Z',
+            updatedAt: '2026-03-30T21:00:00.000Z',
+            localDay: '2026-03-30',
+            entryType: 'symptom_note',
+            title: 'Headache note',
+            body: 'Headache and worry hit after lunch.',
+            tags: [],
+            linkedEventIds: ['symptom-1', 'anxiety-1'],
+          },
+          {
+            id: 'journal-2',
+            createdAt: '2026-03-31T21:00:00.000Z',
+            updatedAt: '2026-03-31T21:00:00.000Z',
+            localDay: '2026-03-31',
+            entryType: 'symptom_note',
+            title: 'Headache note',
+            body: 'Headache and worry hit again after errands.',
+            tags: [],
+            linkedEventIds: ['symptom-2', 'anxiety-2'],
+          },
+        ],
+        foodEntries: [],
+        foodCatalogItems: [],
+        recipeCatalogItems: [],
+        weeklyPlans: [],
+        planSlots: [],
+        derivedGroceryItems: [],
+        manualGroceryItems: [],
+        workoutTemplates: [],
+        exerciseCatalogItems: [],
+        favoriteMeals: [],
+        healthEvents: [
+          {
+            id: 'symptom-1',
+            createdAt: '2026-03-30T09:00:00.000Z',
+            updatedAt: '2026-03-30T09:00:00.000Z',
+            sourceType: 'manual',
+            sourceApp: 'personal-health-cockpit',
+            sourceRecordId: 'symptom:1',
+            sourceTimestamp: '2026-03-30T09:00:00.000Z',
+            localDay: '2026-03-30',
+            timezone: 'UTC',
+            confidence: 1,
+            eventType: 'symptom',
+            value: 4,
+            payload: {
+              kind: 'symptom',
+              symptom: 'Headache',
+              severity: 4,
+            },
+          },
+          {
+            id: 'symptom-2',
+            createdAt: '2026-03-31T09:00:00.000Z',
+            updatedAt: '2026-03-31T09:00:00.000Z',
+            sourceType: 'manual',
+            sourceApp: 'personal-health-cockpit',
+            sourceRecordId: 'symptom:2',
+            sourceTimestamp: '2026-03-31T09:00:00.000Z',
+            localDay: '2026-03-31',
+            timezone: 'UTC',
+            confidence: 1,
+            eventType: 'symptom',
+            value: 4,
+            payload: {
+              kind: 'symptom',
+              symptom: 'Headache',
+              severity: 4,
+            },
+          },
+          {
+            id: 'anxiety-1',
+            createdAt: '2026-03-30T14:00:00.000Z',
+            updatedAt: '2026-03-30T14:00:00.000Z',
+            sourceType: 'manual',
+            sourceApp: 'personal-health-cockpit',
+            sourceRecordId: 'anxiety:1',
+            sourceTimestamp: '2026-03-30T14:00:00.000Z',
+            localDay: '2026-03-30',
+            timezone: 'UTC',
+            confidence: 1,
+            eventType: 'anxiety-episode',
+            value: 6,
+            payload: {
+              kind: 'anxiety',
+              intensity: 6,
+              trigger: 'Crowded store',
+            },
+          },
+          {
+            id: 'anxiety-2',
+            createdAt: '2026-03-31T14:00:00.000Z',
+            updatedAt: '2026-03-31T14:00:00.000Z',
+            sourceType: 'manual',
+            sourceApp: 'personal-health-cockpit',
+            sourceRecordId: 'anxiety:2',
+            sourceTimestamp: '2026-03-31T14:00:00.000Z',
+            localDay: '2026-03-31',
+            timezone: 'UTC',
+            confidence: 1,
+            eventType: 'anxiety-episode',
+            value: 6,
+            payload: {
+              kind: 'anxiety',
+              intensity: 6,
+              trigger: 'Cramped schedule',
+            },
+          },
+        ],
+        healthTemplates: [],
+        sobrietyEvents: [],
+        assessmentResults: [],
+        importBatches: [],
+        importArtifacts: [],
+        reviewSnapshots: [],
+        adherenceMatches: [],
+      },
+    },
+  });
+  expect(seedResponse.ok()).toBe(true);
+
+  await page.goto('/review');
+  await expect(page.getByText('Patterns to watch')).toBeVisible();
+  await expect(page.getByText('Headache kept showing up in your notes on 2 days this week.')).toBeVisible();
+  await expect(page.getByText('Anxiety-related context showed up in your notes on 2 days this week.')).toBeVisible();
+});
+
 test('today recovery links into a prefilled journal note', async ({ page }) => {
   const localDay = new Intl.DateTimeFormat('en-CA', {
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/tests/features/e2e/daily-flows.e2e.ts
+++ b/tests/features/e2e/daily-flows.e2e.ts
@@ -388,8 +388,12 @@ test('weekly review surfaces repeated context patterns', async ({ page }) => {
 
   await page.goto('/review');
   await expect(page.getByText('Patterns to watch')).toBeVisible();
-  await expect(page.getByText('Headache kept showing up in your notes on 2 days this week.')).toBeVisible();
-  await expect(page.getByText('Anxiety-related context showed up in your notes on 2 days this week.')).toBeVisible();
+  await expect(
+    page.getByText('Headache kept showing up in your notes on 2 days this week.')
+  ).toBeVisible();
+  await expect(
+    page.getByText('Anxiety-related context showed up in your notes on 2 days this week.')
+  ).toBeVisible();
 });
 
 test('today recovery links into a prefilled journal note', async ({ page }) => {

--- a/tests/features/unit/review/model.test.ts
+++ b/tests/features/unit/review/model.test.ts
@@ -101,6 +101,7 @@ describe('review model', () => {
         'Evening review on 2026-04-02: Crowded store and headache drained the afternoon.',
       ],
       journalReflectionLinkedEventIds: ['anxiety-1'],
+      patternHighlights: ['Headache kept showing up in your notes on 2 days this week.'],
       experimentOptions: ['Increase hydration tracking'],
     };
 
@@ -111,6 +112,7 @@ describe('review model', () => {
       'Health highlights',
       'Context signals',
       'Journal excerpts',
+      'Patterns to watch',
       'Food adherence highlights',
       'Plan follow-through',
       'Actual vs plan',
@@ -192,6 +194,7 @@ describe('review model', () => {
         'Evening review on 2026-04-02: Crowded store and headache drained the afternoon.',
       ],
       journalReflectionLinkedEventIds: ['anxiety-1'],
+      patternHighlights: ['Headache kept showing up in your notes on 2 days this week.'],
       experimentOptions: ['Increase hydration tracking'],
     };
 
@@ -203,6 +206,9 @@ describe('review model', () => {
     );
     expect(createReviewSections(weekly).map((section) => section.title)).toContain(
       'Journal excerpts'
+    );
+    expect(createReviewSections(weekly).map((section) => section.title)).toContain(
+      'Patterns to watch'
     );
   });
 });

--- a/tests/features/unit/review/service.test.ts
+++ b/tests/features/unit/review/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { saveAssessmentProgress, submitAssessment } from '$lib/features/assessments/service';
 import { deriveWeeklyGroceries, setGroceryItemState } from '$lib/features/groceries/service';
+import { logAnxietyEvent, logSymptomEvent } from '$lib/features/health/service';
 import { commitImportBatch, previewImport } from '$lib/features/imports/service';
 import { saveJournalEntry } from '$lib/features/journal/service';
 import { saveFoodCatalogItem, upsertRecipeCatalogItem } from '$lib/features/nutrition/service';
@@ -144,6 +145,58 @@ describe('review service', () => {
     );
     expect(weekly.journalHighlights).toContain(
       'Evening review on 2026-03-30: Crowded store and headache drained the afternoon.'
+    );
+  });
+
+  it('captures repeated journal-linked patterns in the weekly snapshot', async () => {
+    const db = getDb();
+    await seedWeek();
+
+    const symptomOne = await logSymptomEvent(db, {
+      localDay: '2026-03-30',
+      symptom: 'Headache',
+      severity: 4,
+    });
+    const symptomTwo = await logSymptomEvent(db, {
+      localDay: '2026-03-31',
+      symptom: 'Headache',
+      severity: 4,
+    });
+    const anxietyOne = await logAnxietyEvent(db, {
+      localDay: '2026-03-30',
+      intensity: 6,
+      trigger: 'Crowded store',
+    });
+    const anxietyTwo = await logAnxietyEvent(db, {
+      localDay: '2026-03-31',
+      intensity: 6,
+      trigger: 'Cramped schedule',
+    });
+
+    await saveJournalEntry(db, {
+      localDay: '2026-03-30',
+      entryType: 'symptom_note',
+      title: 'Headache note',
+      body: 'Headache and worry hit after lunch.',
+      tags: [],
+      linkedEventIds: [symptomOne.id, anxietyOne.id],
+    });
+    await saveJournalEntry(db, {
+      localDay: '2026-03-31',
+      entryType: 'symptom_note',
+      title: 'Headache note',
+      body: 'Headache and worry hit again after errands.',
+      tags: [],
+      linkedEventIds: [symptomTwo.id, anxietyTwo.id],
+    });
+
+    const weekly = await buildWeeklySnapshot(db, '2026-04-02');
+
+    expect(weekly.patternHighlights).toContain(
+      'Headache kept showing up in your notes on 2 days this week.'
+    );
+    expect(weekly.patternHighlights).toContain(
+      'Anxiety-related context showed up in your notes on 2 days this week.'
     );
   });
 


### PR DESCRIPTION
Continues Phase 3 by turning repeated linked context into actual weekly review patterns. Review now surfaces repeated symptom and anxiety themes from linked journal context, not just one-off excerpts, with focused unit, component, and E2E coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds weekly pattern detection to Review so repeated journal-linked context is surfaced. Users now see recurring symptom and anxiety themes, not just one-off excerpts.

- **New Features**
  - Detect pattern highlights from `symptom` and `anxiety-episode` events; trigger on 2+ unique days, dedupe within an entry, and fall back to a generic "Symptom" name.
  - Add `patternHighlights` to `WeeklyReviewData`, export `buildPatternHighlights`, and render a "Patterns to watch" section with an empty state until enough signals appear.
  - Wire into the weekly snapshot and add unit, component, and end-to-end tests for detection and display.

- **Refactors**
  - Format `analytics-health.ts` and `tests/features/e2e/daily-flows.e2e.ts` to fix Prettier lint errors.

<sup>Written for commit c44251c24bf141182788543948f72284837841f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---
<!-- grok-describe -->
## 🤖 Grok PR Description

🧪 **Type:** `test`

### Summary
Add 'Patterns to watch' section to weekly review, surfacing repeated symptoms and anxiety episodes from linked journal entries


### Walkthrough
Introduced `buildPatternHighlights` to detect symptoms or anxiety episodes linked to journal entries on 2+ days in the week, generating user-friendly highlights (e.g., 'Headache kept showing up...'). Integrated into `WeeklyReviewData`, computed in `buildWeeklySnapshot`, and rendered as a new 'Patterns to watch' section in review UI. Added comprehensive tests: unit (model/service), component (ReviewPage), e2e (daily-flows). This empowers users to spot recurring health patterns early, improving self-awareness of potential triggers without manual review.




### Changelog Entry
```
feat(review): add patterns to watch section highlighting repeated symptoms/anxiety in journal-linked notes
```
---
*Generated by Grok 4.1 Fast via xAI*
