### PR TITLE
fix(api): harden route contracts and test reset guards

### DIFF
--- a/.github/workflows/grok-describe.yml
+++ b/.github/workflows/grok-describe.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   describe:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '') || (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/grok-threat-monitor.yml
+++ b/.github/workflows/grok-threat-monitor.yml
@@ -121,6 +121,7 @@ jobs:
           fi
 
           git commit -m "chore: threat monitor dependency updates"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push -u origin "$BRANCH"
 
           gh pr create \

--- a/.github/workflows/pr-manager-grok.yml
+++ b/.github/workflows/pr-manager-grok.yml
@@ -27,6 +27,7 @@ jobs:
   manage-pr:
     if: >-
       github.event_name == 'pull_request_target' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '') ||
       (github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository)
     name: PR Manager
     runs-on: ubuntu-latest

--- a/src/lib/core/domain/types.ts
+++ b/src/lib/core/domain/types.ts
@@ -2,12 +2,16 @@ export type RecordId = string;
 export type IsoDateTime = string;
 export type LocalDay = string;
 
-export type ImportSourceType =
-  | 'apple-health-xml'
-  | 'day-one-json'
-  | 'healthkit-companion'
-  | 'smart-fhir-sandbox';
-export type SourceType = 'manual' | 'import' | 'derived' | 'native-companion';
+export const importSourceTypes = [
+  'apple-health-xml',
+  'day-one-json',
+  'healthkit-companion',
+  'smart-fhir-sandbox',
+] as const;
+export type ImportSourceType = (typeof importSourceTypes)[number];
+
+export const sourceTypes = ['manual', 'import', 'derived', 'native-companion'] as const;
+export type SourceType = (typeof sourceTypes)[number];
 export type NativeCompanionConnector = 'healthkit-ios';
 export type NativeCompanionSourcePlatform = 'ios';
 export type HealthTemplateType = 'medication' | 'supplement';
@@ -58,21 +62,25 @@ export interface DailyRecord extends BaseRecord {
 }
 
 export interface JournalEntry extends BaseRecord {
-  entryType:
-    | 'freeform'
-    | 'morning_intention'
-    | 'evening_review'
-    | 'craving_reflection'
-    | 'lapse_reflection'
-    | 'symptom_note'
-    | 'experiment_note'
-    | 'provider_visit_note';
+  entryType: JournalEntryType;
   localDay: LocalDay;
   title?: string;
   body: string;
   tags: string[];
   linkedEventIds: string[];
 }
+
+export const journalEntryTypes = [
+  'freeform',
+  'morning_intention',
+  'evening_review',
+  'craving_reflection',
+  'lapse_reflection',
+  'symptom_note',
+  'experiment_note',
+  'provider_visit_note',
+] as const;
+export type JournalEntryType = (typeof journalEntryTypes)[number];
 
 export interface FoodEntry extends BaseRecord {
   localDay: LocalDay;

--- a/src/lib/features/assessments/service.ts
+++ b/src/lib/features/assessments/service.ts
@@ -98,7 +98,10 @@ export async function submitAssessment(
   }
 ): Promise<AssessmentResult> {
   const definition = getAssessmentDefinition(input.instrument);
-  if (input.itemResponses.length !== definition.questions.length) {
+  if (
+    input.itemResponses.length !== definition.questions.length ||
+    input.itemResponses.some((response) => response < 0)
+  ) {
     throw new Error('Incomplete assessment');
   }
 

--- a/src/lib/features/groceries/parsing.ts
+++ b/src/lib/features/groceries/parsing.ts
@@ -32,7 +32,13 @@ export function inferAisle(label: string): string {
   const normalized = label.toLowerCase();
 
   if (
-    /(berry|apple|banana|lettuce|spinach|kale|onion|tomato|pepper|broccoli|carrot|avocado)/.test(
+    /(black pepper|pepper flakes|red pepper flakes|crushed red pepper|peppercorn)/.test(normalized)
+  ) {
+    return 'Pantry';
+  }
+
+  if (
+    /\b(berry|apple|banana|lettuce|spinach|kale|onion|tomato|pepper|broccoli|carrot|avocado)\b/.test(
       normalized
     )
   ) {
@@ -68,19 +74,26 @@ export function parseIngredientLine(rawLine: string): {
   const tokens = normalized.split(' ');
   const consumed: string[] = [];
   let index = 0;
+  let foundQuantity = false;
 
   while (index < tokens.length) {
     const token = tokens[index]!.toLowerCase();
-    if (
-      /^\d+$/.test(token) ||
-      /^\d+\/\d+$/.test(token) ||
-      /^\d+(?:\.\d+)?$/.test(token) ||
-      COMMON_UNITS.has(token)
-    ) {
+    const isQuantityToken =
+      /^\d+$/.test(token) || /^\d+\/\d+$/.test(token) || /^\d+(?:\.\d+)?$/.test(token);
+
+    if (isQuantityToken) {
+      foundQuantity = true;
       consumed.push(tokens[index]!);
       index += 1;
       continue;
     }
+
+    if (foundQuantity && COMMON_UNITS.has(token)) {
+      consumed.push(tokens[index]!);
+      index += 1;
+      continue;
+    }
+
     break;
   }
 

--- a/src/lib/features/imports/contracts.ts
+++ b/src/lib/features/imports/contracts.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { ImportSourceType } from '$lib/core/domain/types';
+import { importSourceTypes } from '$lib/core/domain/types';
 
 const ownerProfileSchema = z.object({
   fullName: z.string(),
@@ -7,7 +7,7 @@ const ownerProfileSchema = z.object({
 });
 
 const importPreviewInputSchema = z.object({
-  sourceType: z.custom<ImportSourceType>(),
+  sourceType: z.enum(importSourceTypes),
   rawText: z.string(),
   ownerProfile: ownerProfileSchema.nullish(),
 });

--- a/src/lib/features/journal/contracts.ts
+++ b/src/lib/features/journal/contracts.ts
@@ -1,50 +1,53 @@
 import { z } from 'zod';
-import type { JournalPageState } from './controller';
-import type { JournalIntent } from './navigation';
+import { journalEntryTypes } from '$lib/core/domain/types';
 
-function isJournalPageState(value: unknown): value is JournalPageState {
-  if (!value || typeof value !== 'object') return false;
-  const state = value as Record<string, unknown>;
-  const draft = state.draft;
-
-  return (
-    typeof state.loading === 'boolean' &&
-    typeof state.saving === 'boolean' &&
-    typeof state.localDay === 'string' &&
-    typeof state.saveNotice === 'string' &&
-    Array.isArray(state.entries) &&
-    Array.isArray(state.linkedContextRows) &&
-    !!draft &&
-    typeof draft === 'object' &&
-    typeof (draft as Record<string, unknown>).localDay === 'string' &&
-    typeof (draft as Record<string, unknown>).entryType === 'string' &&
-    typeof (draft as Record<string, unknown>).title === 'string' &&
-    typeof (draft as Record<string, unknown>).body === 'string' &&
-    Array.isArray((draft as Record<string, unknown>).tags) &&
-    Array.isArray((draft as Record<string, unknown>).linkedEventIds)
-  );
-}
-
-function isJournalIntent(value: unknown): value is JournalIntent {
-  if (!value || typeof value !== 'object') return false;
-  const intent = value as Record<string, unknown>;
-
-  return (
-    (intent.source === 'today-recovery' || intent.source === 'review-context') &&
-    typeof intent.localDay === 'string' &&
-    typeof intent.entryType === 'string' &&
-    typeof intent.title === 'string' &&
-    typeof intent.body === 'string' &&
-    Array.isArray(intent.linkedEventIds)
-  );
-}
-
-const journalPageStateSchema = z.custom<JournalPageState>(isJournalPageState, {
-  message: 'Invalid journal page state',
+const journalDraftSchema = z.object({
+  id: z.string().optional(),
+  localDay: z.string(),
+  entryType: z.enum(journalEntryTypes),
+  title: z.string(),
+  body: z.string(),
+  tags: z.array(z.string()),
+  linkedEventIds: z.array(z.string()),
 });
 
-const journalIntentSchema = z.custom<JournalIntent>(isJournalIntent, {
-  message: 'Invalid journal intent',
+const journalEntrySchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  localDay: z.string(),
+  entryType: z.enum(journalEntryTypes),
+  title: z.string().optional(),
+  body: z.string(),
+  tags: z.array(z.string()),
+  linkedEventIds: z.array(z.string()),
+});
+
+const journalLinkedContextRowSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  valueLabel: z.string(),
+  sourceLabel: z.string(),
+  selected: z.boolean(),
+});
+
+const journalPageStateSchema = z.object({
+  loading: z.boolean(),
+  saving: z.boolean(),
+  localDay: z.string(),
+  saveNotice: z.string(),
+  entries: z.array(journalEntrySchema),
+  draft: journalDraftSchema,
+  linkedContextRows: z.array(journalLinkedContextRowSchema),
+});
+
+const journalIntentSchema = z.object({
+  source: z.enum(['today-recovery', 'review-context']),
+  localDay: z.string(),
+  entryType: z.enum(journalEntryTypes),
+  title: z.string(),
+  body: z.string(),
+  linkedEventIds: z.array(z.string()),
 });
 
 export const journalRequestSchema = z.discriminatedUnion('action', [

--- a/src/lib/features/movement/service.ts
+++ b/src/lib/features/movement/service.ts
@@ -85,19 +85,27 @@ export async function saveWorkoutTemplate(
   return template;
 }
 
+function normalizeSearchText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, '');
+}
+
 export function searchExerciseCatalog(
   query: string,
   items: ExerciseCatalogItem[]
 ): ExerciseCatalogItem[] {
-  const normalized = query.trim().toLowerCase();
+  const normalized = normalizeSearchText(query);
   if (!normalized) {
     return [];
   }
 
   return items.filter((item) => {
-    const haystack = [item.title, ...item.muscleGroups, ...item.equipment, item.instructions ?? '']
-      .join(' ')
-      .toLowerCase();
+    const haystack = normalizeSearchText(
+      [item.title, ...item.muscleGroups, ...item.equipment, item.instructions ?? ''].join(' ')
+    );
     return haystack.includes(normalized);
   });
 }

--- a/src/lib/features/review/analytics-core.ts
+++ b/src/lib/features/review/analytics-core.ts
@@ -98,9 +98,22 @@ export function generateReviewFlags(
   assessments: AssessmentResult[]
 ): string[] {
   const flags: string[] = [];
+  const lapseLogged = sobrietyEvents.some((event) => event.eventType === 'lapse');
+  const highRiskAssessment = assessments.find((assessment) => assessment.highRisk);
 
   if (!records.length) {
-    flags.push('Need more tracked days before weekly trends can become meaningful.');
+    if (lapseLogged) {
+      flags.push('A lapse was logged this week, so recovery context deserves special attention.');
+    }
+
+    if (highRiskAssessment) {
+      flags.push(`${highRiskAssessment.instrument} entered a high-risk state this week.`);
+    }
+
+    if (!flags.length) {
+      flags.push('Need more tracked days before weekly trends can become meaningful.');
+    }
+
     return flags;
   }
 
@@ -111,11 +124,10 @@ export function generateReviewFlags(
     flags.push('Sleep dipped below 7 hours on multiple tracked days.');
   }
 
-  if (sobrietyEvents.some((event) => event.eventType === 'lapse')) {
+  if (lapseLogged) {
     flags.push('A lapse was logged this week, so recovery context deserves special attention.');
   }
 
-  const highRiskAssessment = assessments.find((assessment) => assessment.highRisk);
   if (highRiskAssessment) {
     flags.push(`${highRiskAssessment.instrument} entered a high-risk state this week.`);
   }
@@ -237,7 +249,7 @@ function buildHeadlineFromTheme(
   decision: ReviewHeadlineDecision,
   recordCount: number
 ): string {
-  if (recordCount === 0) {
+  if (recordCount === 0 && theme !== 'support' && theme !== 'recovery') {
     return 'Need more data to build your first weekly briefing';
   }
 

--- a/src/lib/features/sobriety/contracts.ts
+++ b/src/lib/features/sobriety/contracts.ts
@@ -1,28 +1,30 @@
 import { z } from 'zod';
-import type { SobrietyPageState } from './controller';
 
-function isSobrietyPageState(value: unknown): value is SobrietyPageState {
-  if (!value || typeof value !== 'object') return false;
-  const state = value as Record<string, unknown>;
-  const summary = state.summary;
+const sobrietyEventSchema = z.object({
+  id: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  localDay: z.string(),
+  eventType: z.enum(['status', 'craving', 'lapse', 'recovery']),
+  status: z.enum(['sober', 'lapse', 'recovery']).optional(),
+  cravingScore: z.number().optional(),
+  triggerTags: z.array(z.string()).optional(),
+  recoveryAction: z.string().optional(),
+  note: z.string().optional(),
+});
 
-  return (
-    typeof state.loading === 'boolean' &&
-    typeof state.localDay === 'string' &&
-    typeof state.saveNotice === 'string' &&
-    typeof state.cravingScore === 'string' &&
-    typeof state.cravingNote === 'string' &&
-    typeof state.lapseNote === 'string' &&
-    typeof state.recoveryAction === 'string' &&
-    !!summary &&
-    typeof summary === 'object' &&
-    typeof (summary as Record<string, unknown>).streak === 'number' &&
-    Array.isArray((summary as Record<string, unknown>).todayEvents)
-  );
-}
-
-const sobrietyPageStateSchema = z.custom<SobrietyPageState>(isSobrietyPageState, {
-  message: 'Invalid sobriety page state',
+const sobrietyPageStateSchema = z.object({
+  loading: z.boolean(),
+  localDay: z.string(),
+  summary: z.object({
+    streak: z.number(),
+    todayEvents: z.array(sobrietyEventSchema),
+  }),
+  saveNotice: z.string(),
+  cravingScore: z.string().regex(/^[0-5]$/),
+  cravingNote: z.string(),
+  lapseNote: z.string(),
+  recoveryAction: z.string(),
 });
 
 export const sobrietyRequestSchema = z.discriminatedUnion('action', [

--- a/src/lib/server/db/drizzle/client.ts
+++ b/src/lib/server/db/drizzle/client.ts
@@ -1,21 +1,23 @@
-import { existsSync, rmSync } from 'node:fs';
+import { rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { Database } from 'bun:sqlite';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { DB_VERSION, SCHEMA_STORES } from '$lib/core/db/schema';
 import { drizzleSchema } from './schema';
+import {
+  assertPlaywrightModeForDbReset,
+  isPlaywrightMode,
+  PlaywrightModeRequiredError,
+} from './reset-guard';
 
 const DEFAULT_DB_PATH = join(process.cwd(), '.data', 'personal-health-cockpit.sqlite');
 const PLAYWRIGHT_DB_PATH = '/tmp/personal-health-cockpit-playwright.sqlite';
-const PLAYWRIGHT_MODE_FLAG = join(process.cwd(), '.playwright-mode');
 
 const globalState = globalThis as typeof globalThis & {
   __healthDrizzleClient?: ReturnType<typeof createDrizzleSqliteClient> | null;
 };
 
-function isPlaywrightMode(): boolean {
-  return existsSync(PLAYWRIGHT_MODE_FLAG);
-}
+export { assertPlaywrightModeForDbReset, PlaywrightModeRequiredError };
 
 function indexedColumnsForTable(tableName: keyof typeof SCHEMA_STORES): string[] {
   return SCHEMA_STORES[tableName]
@@ -106,6 +108,7 @@ export function resetServerDrizzleClient(): void {
 }
 
 export function resetServerDrizzleStorage(): void {
+  assertPlaywrightModeForDbReset();
   resetServerDrizzleClient();
   deleteHealthDbFiles();
 }

--- a/src/lib/server/db/drizzle/reset-guard.ts
+++ b/src/lib/server/db/drizzle/reset-guard.ts
@@ -1,0 +1,23 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const PLAYWRIGHT_MODE_FLAG = join(process.cwd(), '.playwright-mode');
+export const PLAYWRIGHT_MODE_REQUIRED_MESSAGE =
+  'Database reset is only available in Playwright mode.';
+
+export class PlaywrightModeRequiredError extends Error {
+  constructor() {
+    super(PLAYWRIGHT_MODE_REQUIRED_MESSAGE);
+    this.name = 'PlaywrightModeRequiredError';
+  }
+}
+
+export function isPlaywrightMode(): boolean {
+  return existsSync(PLAYWRIGHT_MODE_FLAG);
+}
+
+export function assertPlaywrightModeForDbReset(): void {
+  if (!isPlaywrightMode()) {
+    throw new PlaywrightModeRequiredError();
+  }
+}

--- a/src/routes/api/db/migrate/+server.ts
+++ b/src/routes/api/db/migrate/+server.ts
@@ -7,16 +7,82 @@ import {
   importHealthDbSnapshot,
 } from '$lib/server/db/drizzle/import-snapshot';
 
-type MigrationRequest = {
-  snapshot: HealthDbSnapshot & {
-    plannedMeals?: unknown[];
-  };
+const INVALID_MIGRATION_REQUEST_MESSAGE = 'Invalid migration request payload.';
+const SNAPSHOT_KEYS = [
+  'dailyRecords',
+  'journalEntries',
+  'foodEntries',
+  'foodCatalogItems',
+  'recipeCatalogItems',
+  'weeklyPlans',
+  'planSlots',
+  'derivedGroceryItems',
+  'manualGroceryItems',
+  'workoutTemplates',
+  'exerciseCatalogItems',
+  'favoriteMeals',
+  'healthEvents',
+  'healthTemplates',
+  'sobrietyEvents',
+  'assessmentResults',
+  'importBatches',
+  'importArtifacts',
+  'reviewSnapshots',
+  'adherenceMatches',
+] as const satisfies ReadonlyArray<keyof HealthDbSnapshot>;
+
+type MigrationSnapshot = HealthDbSnapshot & {
+  plannedMeals?: unknown[];
 };
 
+type MigrationRequest = {
+  snapshot: MigrationSnapshot;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isMigrationSnapshot(value: unknown): value is MigrationSnapshot {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  for (const key of SNAPSHOT_KEYS) {
+    if (!Array.isArray(value[key])) {
+      return false;
+    }
+  }
+
+  return value.plannedMeals === undefined || Array.isArray(value.plannedMeals);
+}
+
+function parseMigrationRequest(value: unknown): MigrationRequest | null {
+  if (!isRecord(value) || !isMigrationSnapshot(value.snapshot)) {
+    return null;
+  }
+
+  return {
+    snapshot: value.snapshot,
+  };
+}
+
 export const POST: RequestHandler = async ({ request }) => {
-  const body = (await request.json()) as MigrationRequest;
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return new Response(INVALID_MIGRATION_REQUEST_MESSAGE, { status: 400 });
+  }
+
+  const parsed = parseMigrationRequest(body);
+  if (!parsed) {
+    return new Response(INVALID_MIGRATION_REQUEST_MESSAGE, { status: 400 });
+  }
+
   const { db } = getServerDrizzleClient();
-  const { snapshot } = body;
+  const { snapshot } = parsed;
 
   await importHealthDbSnapshot(db, snapshot);
 

--- a/src/routes/api/test/reset-db/+server.ts
+++ b/src/routes/api/test/reset-db/+server.ts
@@ -1,6 +1,9 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { resetServerDrizzleStorage } from '$lib/server/db/drizzle/client';
+import {
+  PlaywrightModeRequiredError,
+  resetServerDrizzleStorage,
+} from '$lib/server/db/drizzle/client';
 
 const HEALTH_RESET_TOKEN = 'codex-e2e';
 
@@ -10,6 +13,14 @@ export const POST: RequestHandler = async ({ request }) => {
     return new Response('Forbidden', { status: 403 });
   }
 
-  resetServerDrizzleStorage();
+  try {
+    resetServerDrizzleStorage();
+  } catch (error) {
+    if (error instanceof PlaywrightModeRequiredError) {
+      return new Response('Forbidden', { status: 403 });
+    }
+    throw error;
+  }
+
   return json({ ok: true });
 };

--- a/src/routes/api/timeline/+server.ts
+++ b/src/routes/api/timeline/+server.ts
@@ -1,15 +1,28 @@
 import { z } from 'zod';
 import type { RequestHandler } from './$types';
-import {
-  loadTimelinePageServer,
-  type TimelineEventItem,
-  type TimelineSourceFilter,
-} from '$lib/server/timeline/service';
+import type { TimelinePageState } from '$lib/features/timeline/controller';
+import { sourceTypes } from '$lib/core/domain/types';
+import { loadTimelinePageServer } from '$lib/server/timeline/service';
+
+const timelineEventSchema = z
+  .object({
+    sourceType: z.enum(sourceTypes),
+  })
+  .passthrough();
+
+const timelineEventItemSchema = z
+  .object({
+    event: timelineEventSchema,
+    label: z.string(),
+    valueLabel: z.string(),
+    sourceLabel: z.string(),
+  })
+  .passthrough();
 
 const timelinePageStateSchema = z.object({
   loading: z.boolean(),
-  filter: z.custom<TimelineSourceFilter>(),
-  items: z.array(z.custom<TimelineEventItem>()),
+  filter: z.union([z.literal('all'), z.enum(sourceTypes)]),
+  items: z.array(timelineEventItemSchema),
 });
 
 export const POST: RequestHandler = async ({ request }) => {
@@ -32,5 +45,7 @@ export const POST: RequestHandler = async ({ request }) => {
     return new Response('Invalid timeline request payload.', { status: 400 });
   }
 
-  return Response.json(await loadTimelinePageServer(parsed.data.state));
+  return Response.json(
+    await loadTimelinePageServer(parsed.data.state as unknown as TimelinePageState)
+  );
 };

--- a/tests/ci/workflow-invariants.test.ts
+++ b/tests/ci/workflow-invariants.test.ts
@@ -58,6 +58,38 @@ describe('workflow structure invariants', () => {
     expect(perms['pull-requests']).toBe('read');
   });
 
+  it('workflow_dispatch workflows admit dispatch in their job guards', () => {
+    const prManager = readWorkflow('pr-manager-grok.yml');
+    const grokDescribe = readWorkflow('grok-describe.yml');
+    expect(prManager).not.toBeNull();
+    expect(grokDescribe).not.toBeNull();
+
+    const prManagerJobs = prManager!.jobs as Record<string, Record<string, unknown>>;
+    const describeJobs = grokDescribe!.jobs as Record<string, Record<string, unknown>>;
+
+    expect(String(prManagerJobs['manage-pr']?.if ?? '')).toContain(
+      "github.event_name == 'workflow_dispatch'"
+    );
+    expect(String(prManagerJobs['manage-pr']?.if ?? '')).toContain(
+      "github.event.inputs.pr_number != ''"
+    );
+    expect(String(describeJobs['describe']?.if ?? '')).toContain(
+      "github.event_name == 'workflow_dispatch'"
+    );
+    expect(String(describeJobs['describe']?.if ?? '')).toContain(
+      "github.event.inputs.pr_number != ''"
+    );
+  });
+
+  it('grok-threat-monitor has an authenticated push path without permission widening', () => {
+    const wf = readWorkflow('grok-threat-monitor.yml');
+    expect(wf).not.toBeNull();
+    const perms = wf!.permissions as Record<string, string>;
+    expect(perms['contents']).toBe('write');
+    const content = JSON.stringify(wf);
+    expect(content).toContain('git remote set-url origin');
+    expect(content).toContain('x-access-token:${GITHUB_TOKEN}');
+  });
   it('audit doc "what was reviewed" entries match real workflow files', () => {
     const workflowsDir = resolve(__dirname, '../../.github/workflows');
     const reviewedWorkflows = [

--- a/tests/features/unit/assessments/controller.test.ts
+++ b/tests/features/unit/assessments/controller.test.ts
@@ -53,4 +53,18 @@ describe('assessments controller', () => {
 
     expect(state.validationError).toMatch(/incomplete assessment/i);
   });
+
+  it('surfaces validation errors when unanswered sentinel values remain in a full-length draft', async () => {
+    const db = getDb();
+    let state = await loadAssessmentsPage(db, '2026-04-02', createAssessmentsPageState());
+    state = {
+      ...state,
+      draftResponses: [1, -1, 2, -1, -1, -1, -1, -1, -1],
+    };
+
+    state = await submitAssessmentsPage(db, state);
+
+    expect(state.validationError).toMatch(/incomplete assessment/i);
+    expect(state.latest).toBeUndefined();
+  });
 });

--- a/tests/features/unit/assessments/service.test.ts
+++ b/tests/features/unit/assessments/service.test.ts
@@ -49,6 +49,17 @@ describe('assessment service', () => {
     ).rejects.toThrow(/Incomplete assessment/);
   });
 
+  it('rejects full-length submissions that still contain unanswered sentinel values', async () => {
+    const db = getDb();
+    await expect(
+      submitAssessment(db, {
+        localDay: '2026-04-02',
+        instrument: 'PHQ-9',
+        itemResponses: [1, -1, 2, -1, -1, -1, -1, -1, -1],
+      })
+    ).rejects.toThrow(/Incomplete assessment/);
+  });
+
   it('submits complete results with score, band, and risk metadata', async () => {
     const db = getDb();
     const result = await submitAssessment(db, {

--- a/tests/features/unit/db/migrate.route.test.ts
+++ b/tests/features/unit/db/migrate.route.test.ts
@@ -22,10 +22,8 @@ describe('db migrate route', () => {
     return await import('../../../../src/routes/api/db/migrate/+server.ts');
   }
 
-  it('ignores legacy plannedMeals data when importing a snapshot', async () => {
-    const importHealthDbSnapshot = vi.fn(async () => undefined);
-    const countMigratedRecords = vi.fn(() => 0);
-    const snapshot = {
+  function createSnapshot(): HealthDbSnapshot & { plannedMeals?: unknown[] } {
+    return {
       dailyRecords: [],
       journalEntries: [],
       foodEntries: [],
@@ -46,6 +44,56 @@ describe('db migrate route', () => {
       importArtifacts: [],
       reviewSnapshots: [],
       adherenceMatches: [],
+    };
+  }
+
+  it('returns 400 for malformed JSON bodies', async () => {
+    const importHealthDbSnapshot = vi.fn(async () => undefined);
+    const countMigratedRecords = vi.fn(() => 0);
+    const { POST } = await importRoute({ importHealthDbSnapshot, countMigratedRecords });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/db/migrate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{',
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid migration request payload.');
+    expect(importHealthDbSnapshot).not.toHaveBeenCalled();
+    expect(countMigratedRecords).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid snapshot shapes', async () => {
+    const importHealthDbSnapshot = vi.fn(async () => undefined);
+    const countMigratedRecords = vi.fn(() => 0);
+    const { POST } = await importRoute({ importHealthDbSnapshot, countMigratedRecords });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/db/migrate', {
+        method: 'POST',
+        body: JSON.stringify({
+          snapshot: {
+            ...createSnapshot(),
+            dailyRecords: {},
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid migration request payload.');
+    expect(importHealthDbSnapshot).not.toHaveBeenCalled();
+    expect(countMigratedRecords).not.toHaveBeenCalled();
+  });
+
+  it('ignores legacy plannedMeals data when importing a snapshot', async () => {
+    const importHealthDbSnapshot = vi.fn(async () => undefined);
+    const countMigratedRecords = vi.fn(() => 0);
+    const snapshot = {
+      ...createSnapshot(),
       plannedMeals: [
         {
           id: 'planned-meal:next',

--- a/tests/features/unit/db/reset-db.route.test.ts
+++ b/tests/features/unit/db/reset-db.route.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('reset-db route', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/server/db/drizzle/client');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function importRoute(overrides?: { resetServerDrizzleStorage?: ReturnType<typeof vi.fn> }) {
+    class MockPlaywrightModeRequiredError extends Error {
+      constructor() {
+        super('Database reset is only available in Playwright mode.');
+        this.name = 'PlaywrightModeRequiredError';
+      }
+    }
+
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      PlaywrightModeRequiredError: MockPlaywrightModeRequiredError,
+      resetServerDrizzleStorage: overrides?.resetServerDrizzleStorage ?? vi.fn(() => undefined),
+    }));
+
+    const route = await import('../../../../src/routes/api/test/reset-db/+server.ts');
+    return { ...route, MockPlaywrightModeRequiredError };
+  }
+
+  it('returns 403 when the reset token is missing or invalid', async () => {
+    const resetServerDrizzleStorage = vi.fn(() => undefined);
+    const { POST } = await importRoute({ resetServerDrizzleStorage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/test/reset-db', {
+        method: 'POST',
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('Forbidden');
+    expect(resetServerDrizzleStorage).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the helper refuses outside playwright mode', async () => {
+    const { POST, MockPlaywrightModeRequiredError } = await importRoute({
+      resetServerDrizzleStorage: vi.fn(() => {
+        throw new MockPlaywrightModeRequiredError();
+      }),
+    });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/test/reset-db', {
+        method: 'POST',
+        headers: { 'x-health-reset-token': 'codex-e2e' },
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('Forbidden');
+  });
+
+  it('returns ok when the helper succeeds', async () => {
+    const resetServerDrizzleStorage = vi.fn(() => undefined);
+    const { POST } = await importRoute({ resetServerDrizzleStorage });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/test/reset-db', {
+        method: 'POST',
+        headers: { 'x-health-reset-token': 'codex-e2e' },
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(resetServerDrizzleStorage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('resetServerDrizzleStorage guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('refuses destructive reset outside playwright mode', async () => {
+    const { PlaywrightModeRequiredError, assertPlaywrightModeForDbReset } =
+      await import('../../../../src/lib/server/db/drizzle/reset-guard.ts');
+
+    expect(() => assertPlaywrightModeForDbReset()).toThrow(PlaywrightModeRequiredError);
+  });
+});

--- a/tests/features/unit/groceries/derivation.test.ts
+++ b/tests/features/unit/groceries/derivation.test.ts
@@ -28,6 +28,24 @@ describe('groceries derivation helpers', () => {
       label: 'baby spinach',
       quantityText: undefined,
     });
+
+    expect(parseIngredientLine('cup noodles')).toEqual({
+      ingredientKey: 'cup noodles',
+      label: 'cup noodles',
+      quantityText: undefined,
+    });
+
+    expect(parseIngredientLine('bottle brush')).toEqual({
+      ingredientKey: 'bottle brush',
+      label: 'bottle brush',
+      quantityText: undefined,
+    });
+
+    expect(parseIngredientLine('1 bottle soy sauce')).toEqual({
+      ingredientKey: 'soy sauce',
+      label: 'soy sauce',
+      quantityText: '1 bottle',
+    });
   });
 
   it('infers aisles and preserves manual state when building manual records', () => {
@@ -77,6 +95,8 @@ describe('groceries derivation helpers', () => {
       onHand: true,
     });
     expect(inferAisle('Greek yogurt bowl')).toBe('Protein & Dairy');
+    expect(inferAisle('black pepper')).toBe('Pantry');
+    expect(inferAisle('pepper flakes')).toBe('Pantry');
   });
 
   it('merges derived and manual grocery rows into stable combined items', () => {

--- a/tests/features/unit/imports/route.test.ts
+++ b/tests/features/unit/imports/route.test.ts
@@ -127,6 +127,22 @@ describe('imports route', () => {
     expect(invalid.status).toBe(400);
     expect(await invalid.text()).toBe('Invalid import request payload.');
 
+    const invalidSourceType = await POST({
+      request: new Request('http://health.test/api/imports', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'preview',
+          input: {
+            sourceType: 'bogus',
+            rawText: '{}',
+            ownerProfile: null,
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidSourceType.status).toBe(400);
+    expect(await invalidSourceType.text()).toBe('Invalid import request payload.');
+
     const failing = await POST({
       request: new Request('http://health.test/api/imports', {
         method: 'POST',

--- a/tests/features/unit/journal/route.test.ts
+++ b/tests/features/unit/journal/route.test.ts
@@ -126,5 +126,79 @@ describe('journal route', () => {
     } as Parameters<typeof POST>[0]);
     expect(response.status).toBe(400);
     expect(await response.text()).toBe('Invalid journal request payload.');
+
+    const state = {
+      loading: false,
+      saving: false,
+      localDay: '2026-04-04',
+      saveNotice: '',
+      entries: [],
+      linkedContextRows: [],
+      draft: {
+        localDay: '2026-04-04',
+        entryType: 'bogus',
+        title: '',
+        body: '',
+        tags: [],
+        linkedEventIds: [],
+      },
+    };
+
+    const invalidDraftEntryType = await POST({
+      request: new Request('http://health.test/api/journal', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'save', state }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidDraftEntryType.status).toBe(400);
+    expect(await invalidDraftEntryType.text()).toBe('Invalid journal request payload.');
+
+    const validState = {
+      ...state,
+      draft: {
+        ...state.draft,
+        entryType: 'freeform',
+      },
+    };
+
+    const invalidIntentEntryType = await POST({
+      request: new Request('http://health.test/api/journal', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'hydrateIntent',
+          state: validState,
+          intent: {
+            source: 'today-recovery',
+            localDay: '2026-04-04',
+            entryType: 'bogus',
+            title: 'Recovery note',
+            body: 'Crowded store and headache drained the afternoon.',
+            linkedEventIds: ['symptom-1'],
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidIntentEntryType.status).toBe(400);
+    expect(await invalidIntentEntryType.text()).toBe('Invalid journal request payload.');
+
+    const invalidIntentSource = await POST({
+      request: new Request('http://health.test/api/journal', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'hydrateIntent',
+          state: validState,
+          intent: {
+            source: 'bogus',
+            localDay: '2026-04-04',
+            entryType: 'symptom_note',
+            title: 'Recovery note',
+            body: 'Crowded store and headache drained the afternoon.',
+            linkedEventIds: ['symptom-1'],
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidIntentSource.status).toBe(400);
+    expect(await invalidIntentSource.text()).toBe('Invalid journal request payload.');
   });
 });

--- a/tests/features/unit/movement/service.test.ts
+++ b/tests/features/unit/movement/service.test.ts
@@ -33,6 +33,48 @@ describe('movement service', () => {
     ]);
   });
 
+  it('normalizes separators and whitespace when searching the exercise catalog', async () => {
+    const db = getDb();
+    await upsertExerciseCatalogItems(db, [
+      {
+        id: 'wger:2',
+        createdAt: '2026-04-03T00:00:00.000Z',
+        updatedAt: '2026-04-03T00:00:00.000Z',
+        sourceType: 'wger',
+        externalId: '2',
+        title: 'Push-up',
+        muscleGroups: ['Chest'],
+        equipment: ['Bodyweight'],
+        instructions: 'Press back to the top.',
+      },
+      {
+        id: 'wger:3',
+        createdAt: '2026-04-03T00:00:00.000Z',
+        updatedAt: '2026-04-03T00:00:00.000Z',
+        sourceType: 'wger',
+        externalId: '3',
+        title: 'Lat pulldown',
+        muscleGroups: ['Back'],
+        equipment: ['Cable'],
+        instructions: 'Pull the bar to your chest.',
+      },
+    ]);
+
+    const items = await db.exerciseCatalogItems.toArray();
+    expect(searchExerciseCatalog('push up', items)).toEqual([
+      expect.objectContaining({ title: 'Push-up' }),
+    ]);
+    expect(searchExerciseCatalog('push-up', items)).toEqual([
+      expect.objectContaining({ title: 'Push-up' }),
+    ]);
+    expect(searchExerciseCatalog('lat pull down', items)).toEqual([
+      expect.objectContaining({ title: 'Lat pulldown' }),
+    ]);
+    expect(searchExerciseCatalog('pulldown', items)).toEqual([
+      expect.objectContaining({ title: 'Lat pulldown' }),
+    ]);
+  });
+
   it('stores workout templates for later planning surfaces', async () => {
     const db = getDb();
     const template = await saveWorkoutTemplate(db, {

--- a/tests/features/unit/review/analytics.test.ts
+++ b/tests/features/unit/review/analytics.test.ts
@@ -16,6 +16,7 @@ import {
   buildNutritionStrategy,
   computeCorrelations,
   computeTrendComparisonsFromData,
+  generateReviewFlags,
   weekRangeFromAnchorDay,
 } from '$lib/features/review/analytics';
 
@@ -166,6 +167,99 @@ describe('review analytics', () => {
         recommendation: null,
       })
     ).toBe('First signal logged, keep the streak going');
+  });
+
+  it('keeps lapse and high-risk sparse-week signals ahead of generic no-data fallback', () => {
+    expect(
+      generateReviewFlags(
+        [],
+        [
+          {
+            id: 'sobriety-1',
+            createdAt: '2026-04-01T08:00:00.000Z',
+            updatedAt: '2026-04-01T08:00:00.000Z',
+            localDay: '2026-04-01',
+            eventType: 'lapse',
+            status: 'lapse',
+          },
+        ],
+        [
+          {
+            id: 'assessment-1',
+            createdAt: '2026-04-01T08:00:00.000Z',
+            updatedAt: '2026-04-01T08:00:00.000Z',
+            localDay: '2026-04-01',
+            instrument: 'WHO-5',
+            version: 1,
+            recallWindow: 'last 2 weeks',
+            itemResponses: [0, 0, 0, 0, 0],
+            isComplete: true,
+            highRisk: true,
+            totalScore: 0,
+            band: 'High risk',
+          },
+        ]
+      )
+    ).toEqual([
+      'A lapse was logged this week, so recovery context deserves special attention.',
+      'WHO-5 entered a high-risk state this week.',
+    ]);
+
+    expect(
+      buildHeadline({
+        records: [],
+        assessments: [
+          {
+            id: 'assessment-1',
+            createdAt: '2026-04-01T08:00:00.000Z',
+            updatedAt: '2026-04-01T08:00:00.000Z',
+            localDay: '2026-04-01',
+            instrument: 'WHO-5',
+            version: 1,
+            recallWindow: 'last 2 weeks',
+            itemResponses: [0, 0, 0, 0, 0],
+            isComplete: true,
+            highRisk: true,
+            totalScore: 0,
+            band: 'High risk',
+          },
+        ],
+        sobrietyEvents: [
+          {
+            id: 'sobriety-1',
+            createdAt: '2026-04-01T08:00:00.000Z',
+            updatedAt: '2026-04-01T08:00:00.000Z',
+            localDay: '2026-04-01',
+            eventType: 'lapse',
+            status: 'lapse',
+          },
+        ],
+        healthEvents: [],
+        journalEntries: [],
+        averageProtein: 0,
+        adherenceScores: [],
+        recommendation: null,
+      })
+    ).toBe('Support first, metrics second');
+  });
+
+  it('keeps conservative no-data fallback when a sparse week has no stronger signals', () => {
+    expect(generateReviewFlags([], [], [])).toEqual([
+      'Need more tracked days before weekly trends can become meaningful.',
+    ]);
+
+    expect(
+      buildHeadline({
+        records: [],
+        assessments: [],
+        sobrietyEvents: [],
+        healthEvents: [],
+        journalEntries: [],
+        averageProtein: 0,
+        adherenceScores: [],
+        recommendation: null,
+      })
+    ).toBe('Need more data to build your first weekly briefing');
   });
 
   it('builds structured nutrition strategy items for review actions', () => {

--- a/tests/features/unit/sobriety/route.test.ts
+++ b/tests/features/unit/sobriety/route.test.ts
@@ -135,5 +135,90 @@ describe('sobriety route', () => {
     } as Parameters<typeof POST>[0]);
     expect(response.status).toBe(400);
     expect(await response.text()).toBe('Invalid sobriety request payload.');
+
+    const invalidCravingScoreState = {
+      loading: false,
+      localDay: '2026-04-04',
+      summary: { streak: 1, todayEvents: [] },
+      saveNotice: '',
+      cravingScore: '',
+      cravingNote: '',
+      lapseNote: '',
+      recoveryAction: '',
+    };
+
+    const invalidCravingScore = await POST({
+      request: new Request('http://health.test/api/sobriety', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'saveCraving', state: invalidCravingScoreState }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidCravingScore.status).toBe(400);
+    expect(await invalidCravingScore.text()).toBe('Invalid sobriety request payload.');
+
+    const invalidEventTypeState = {
+      loading: false,
+      localDay: '2026-04-04',
+      summary: {
+        streak: 1,
+        todayEvents: [
+          {
+            id: 'sobriety-1',
+            createdAt: '2026-04-04T08:00:00.000Z',
+            updatedAt: '2026-04-04T08:00:00.000Z',
+            localDay: '2026-04-04',
+            eventType: 'bogus',
+          },
+        ],
+      },
+      saveNotice: '',
+      cravingScore: '3',
+      cravingNote: '',
+      lapseNote: '',
+      recoveryAction: '',
+    };
+
+    const invalidEventType = await POST({
+      request: new Request('http://health.test/api/sobriety', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'load',
+          localDay: '2026-04-04',
+          state: invalidEventTypeState,
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidEventType.status).toBe(400);
+    expect(await invalidEventType.text()).toBe('Invalid sobriety request payload.');
+
+    const invalidStatusState = {
+      ...invalidEventTypeState,
+      summary: {
+        streak: 1,
+        todayEvents: [
+          {
+            id: 'sobriety-1',
+            createdAt: '2026-04-04T08:00:00.000Z',
+            updatedAt: '2026-04-04T08:00:00.000Z',
+            localDay: '2026-04-04',
+            eventType: 'status',
+            status: 'unknown',
+          },
+        ],
+      },
+    };
+
+    const invalidStatus = await POST({
+      request: new Request('http://health.test/api/sobriety', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'load',
+          localDay: '2026-04-04',
+          state: invalidStatusState,
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidStatus.status).toBe(400);
+    expect(await invalidStatus.text()).toBe('Invalid sobriety request payload.');
   });
 });

--- a/tests/features/unit/timeline/route.test.ts
+++ b/tests/features/unit/timeline/route.test.ts
@@ -58,14 +58,51 @@ describe('timeline route', () => {
 
   it('returns 400 for invalid timeline payloads', async () => {
     const { POST } = await importRoute({});
-    const response = await POST({
+    const missingState = await POST({
       request: new Request('http://health.test/api/timeline', {
         method: 'POST',
         body: JSON.stringify({ action: 'load' }),
       }),
     } as Parameters<typeof POST>[0]);
 
-    expect(response.status).toBe(400);
-    expect(await response.text()).toBe('Invalid timeline request payload.');
+    expect(missingState.status).toBe(400);
+    expect(await missingState.text()).toBe('Invalid timeline request payload.');
+
+    const invalidFilter = await POST({
+      request: new Request('http://health.test/api/timeline', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'load',
+          state: { loading: true, filter: 'bogus', items: [] },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(invalidFilter.status).toBe(400);
+    expect(await invalidFilter.text()).toBe('Invalid timeline request payload.');
+
+    const invalidItemEventSource = await POST({
+      request: new Request('http://health.test/api/timeline', {
+        method: 'POST',
+        body: JSON.stringify({
+          action: 'load',
+          state: {
+            loading: true,
+            filter: 'all',
+            items: [
+              {
+                event: { sourceType: 'bogus' },
+                label: 'Resting heart rate',
+                valueLabel: '57 bpm',
+                sourceLabel: 'Native companion',
+              },
+            ],
+          },
+        }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(invalidItemEventSource.status).toBe(400);
+    expect(await invalidItemEventSource.text()).toBe('Invalid timeline request payload.');
   });
 });


### PR DESCRIPTION
## Summary
- harden route contract parsing across migrate, imports, journal, sobriety, and timeline flows using enum-backed schemas and explicit invalid-payload guards
- block destructive test database resets outside Playwright mode and add route coverage for the new reset guard
- patch Grok workflow dispatch and authenticated push paths, plus review analytics sparse-week fallback behavior and matching CI invariants

## Verification
- bun run check
- bun run test:unit
- bun run lint
- bun run build

## Summary by Sourcery

Harden API contracts, validation, and test reset safeguards while tightening CI workflow guards and refining analytics, groceries, movement search, and assessments behavior.

Bug Fixes:
- Validate migration route payloads and reject malformed JSON or invalid snapshot shapes before importing data.
- Enforce enum-backed payload contracts for imports, journal, sobriety, and timeline routes to reject invalid source types, entry types, filters, and event sources.
- Guard test database reset behind Playwright mode and return forbidden responses when the reset is invoked in unsupported environments.
- Ensure sparse-week review analytics prioritize lapse and high-risk signals over generic no-data fallbacks and keep conservative messaging when no strong signals exist.
- Treat assessments with unanswered sentinel values as incomplete both in the service and controller flows.

Enhancements:
- Replace loose type guards with structured zod schemas and shared enums for journal, sobriety, imports, and timeline state and intent validation.
- Normalize exercise search text to handle separator and whitespace variations when matching catalog items.
- Improve grocery ingredient parsing and aisle inference for edge cases like quantity-plus-unit phrases and pepper-related items.

CI:
- Allow Grok-related workflows to run safely via workflow_dispatch with explicit input guards and add an authenticated push path for the threat monitor workflow without broadening permissions.

Tests:
- Add unit coverage for invalid payload handling across migrate, journal, sobriety, imports, and timeline routes, including the new migration and reset-db guards.
- Extend analytics, groceries, movement, and assessments tests to cover new sparse-week behavior, parsing rules, search normalization, and incomplete assessment handling.
- Add CI workflow invariant tests to assert workflow_dispatch conditions and authenticated push behavior for Grok workflows.

---
<!-- grok-describe -->
## 🤖 Grok PR Description

💥 **Type:** `breaking`

> ⚠️ **BREAKING CHANGE** - This PR introduces breaking changes!

### Summary
Harden API route contracts with Zod validation and add DB reset guards to protect health data integrity


### Walkthrough
- Converted union types to const-enum pairs (e.g., ImportSourceType, JournalEntryType) for exhaustive Zod validation.
- Added Zod schemas to journal/sobriety/timeline/imports/migrate routes; reject malformed requests with 400.
- Enforced non-negative responses in assessments; fail incomplete/full-sentinel submissions.
- Guarded resetServerDrizzleStorage() behind .playwright-mode flag; route catches and 403s.
- Enhanced review flags for no-data weeks with lapse/high-risk prioritization.
- Workflow tweaks for dispatch/PR safety; tests cover all new validations.
- No schema migrations; breaking due to stricter API contracts.

### Highlights
- Ensures health data (assessments, sobriety, journal) integrity via runtime validation
- Prevents prod DB wipes with reset guards
- Prioritizes critical signals (lapses, high-risk) in sparse review weeks



### Changelog Entry
```
fix(api): harden route contracts and test reset guards

Prevents invalid payloads from corrupting health records (e.g., assessments, journal entries, sobriety events) by enforcing strict Zod schemas on all major routes. Adds Playwright-only guard for DB resets to avoid accidental data loss in production. Improves sparse-week review flags to prioritize lapses/high-risk signals. Minor fixes to grocery parsing, exercise search, and workflows.
```
---
*Generated by Grok 4.1 Fast via xAI*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened API payload validation using enum-backed schemas across migrate, imports, journal, sobriety, and timeline routes, and added a Playwright-only guard for destructive test DB resets. Also patched Grok workflows to support workflow_dispatch and authenticated pushes, and tuned review analytics for sparse weeks.

- **Bug Fixes**
  - API: Strict zod schemas with enums for `sourceTypes`, `importSourceTypes`, and `journalEntryTypes`; invalid payloads now return 400 with clear messages.
  - Test DB reset: Blocks resets outside Playwright mode; route returns 403 on missing/invalid token or non-Playwright runs.
  - Behavioral tweaks: Assessments reject sentinel responses (-1); groceries parser improves quantity detection and maps pepper variants to Pantry; exercise search normalizes separators/whitespace; review flags/headlines keep lapse and high-risk signals even with sparse data.
  - CI: Grok workflows accept workflow_dispatch with `pr_number` and push via an authenticated remote in threat monitor without widening permissions.

<sup>Written for commit eb182c84297e560c399f8463edf57ff85614a1fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

