### PR TITLE
[codex] harden external-source flows and companion exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/.old_modules-*
 /build
 /coverage
 /playwright-report
+/graphify-out
 
 # OS
 .DS_Store

--- a/apps/ios-companion/Core/HealthKitExportMode.swift
+++ b/apps/ios-companion/Core/HealthKitExportMode.swift
@@ -11,7 +11,7 @@ enum HealthKitExportMode: String, CaseIterable, Identifiable {
 		case .dailySnapshot:
 			return "Daily snapshot"
 		case .incrementalChanges:
-			return "Changes since last export"
+			return "Today changes since last sync"
 		}
 	}
 
@@ -20,7 +20,7 @@ enum HealthKitExportMode: String, CaseIterable, Identifiable {
 		case .dailySnapshot:
 			return "Exports one compact daily bundle with sleep duration, total steps, and the latest resting heart rate."
 		case .incrementalChanges:
-			return "Uses anchored HealthKit queries to export only new matching samples since the last successful export."
+			return "Uses anchored HealthKit queries to export new matching samples from today since the last successful local sync."
 		}
 	}
 }

--- a/apps/ios-companion/HealthKit/HealthKitBundleExporter.swift
+++ b/apps/ios-companion/HealthKit/HealthKitBundleExporter.swift
@@ -3,7 +3,34 @@ import HealthKit
 import UIKit
 
 protocol HealthKitBundleExporting {
-	func exportBundle(for day: Date, mode: HealthKitExportMode) async throws -> HealthKitBridgeBundle
+	func exportBundle(for day: Date, mode: HealthKitExportMode) async throws -> HealthKitBridgeBundleExportResult
+}
+
+enum HealthKitBundleExportError: LocalizedError, Equatable {
+	case emptyBundle
+
+	var errorDescription: String? {
+		switch self {
+		case .emptyBundle:
+			return "No matching HealthKit samples were available for this export."
+		}
+	}
+}
+
+struct HealthKitBridgeBundleExportResult {
+	let bundle: HealthKitBridgeBundle
+	private let anchorCommits: [() -> Void]
+
+	init(bundle: HealthKitBridgeBundle, anchorCommits: [() -> Void]) {
+		self.bundle = bundle
+		self.anchorCommits = anchorCommits
+	}
+
+	func commitAnchors() {
+		for commit in anchorCommits {
+			commit()
+		}
+	}
 }
 
 struct HealthKitBundleExporter: HealthKitBundleExporting {
@@ -30,9 +57,10 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 		self.iso8601Formatter = formatter
 	}
 
-	func exportBundle(for day: Date, mode: HealthKitExportMode) async throws -> HealthKitBridgeBundle {
+	func exportBundle(for day: Date, mode: HealthKitExportMode) async throws -> HealthKitBridgeBundleExportResult {
 		let dayWindow = DayWindow(day: day, calendar: calendar)
 		let records: [HealthKitBridgeRecord]
+		let anchorCommits: [() -> Void]
 
 		switch mode {
 		case .dailySnapshot:
@@ -44,22 +72,30 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 			let stepRecord = try await steps
 			let restingHeartRateRecord = try await restingHeartRate
 			records = [sleepRecord, stepRecord, restingHeartRateRecord].compactMap { $0 }
+			anchorCommits = []
 		case .incrementalChanges:
-			records = try await incrementalRecords(for: dayWindow)
+			let incremental = try await incrementalRecords(for: dayWindow)
+			records = incremental.records
+			anchorCommits = incremental.anchorCommits
+		}
+
+		guard !records.isEmpty else {
+			throw HealthKitBundleExportError.emptyBundle
 		}
 
 		let capturedAt = iso8601Formatter.string(from: .now)
-
-		return HealthKitBridgeBundle.make(
+		let bundle = HealthKitBridgeBundle.make(
 			deviceId: UIDevice.current.identifierForVendor?.uuidString ?? UIDevice.current.name,
 			deviceName: UIDevice.current.name,
 			capturedAt: capturedAt,
 			timezone: timeZone.identifier,
 			records: records
 		)
+
+		return HealthKitBridgeBundleExportResult(bundle: bundle, anchorCommits: anchorCommits)
 	}
 
-	private func incrementalRecords(for dayWindow: DayWindow) async throws -> [HealthKitBridgeRecord] {
+	private func incrementalRecords(for dayWindow: DayWindow) async throws -> (records: [HealthKitBridgeRecord], anchorCommits: [() -> Void]) {
 		async let sleep = incrementalSleepRecords(for: dayWindow)
 		async let steps = incrementalQuantityRecords(
 			for: .stepCount,
@@ -74,7 +110,14 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 			unit: HKUnit.count().unitDivided(by: HKUnit.minute())
 		)
 
-		return try await sleep + steps + restingHeartRate
+		let sleepResult = try await sleep
+		let stepsResult = try await steps
+		let restingHeartRateResult = try await restingHeartRate
+
+		return (
+			records: sleepResult.records + stepsResult.records + restingHeartRateResult.records,
+			anchorCommits: sleepResult.anchorCommits + stepsResult.anchorCommits + restingHeartRateResult.anchorCommits
+		)
 	}
 
 	private func sleepRecord(for dayWindow: DayWindow) async throws -> HealthKitBridgeRecord? {
@@ -213,9 +256,9 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 		(value * 10).rounded() / 10
 	}
 
-	private func incrementalSleepRecords(for dayWindow: DayWindow) async throws -> [HealthKitBridgeRecord] {
+	private func incrementalSleepRecords(for dayWindow: DayWindow) async throws -> (records: [HealthKitBridgeRecord], anchorCommits: [() -> Void]) {
 		guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else {
-			return []
+			return (records: [], anchorCommits: [])
 		}
 
 		let predicate = HKQuery.predicateForSamples(withStart: dayWindow.start, end: dayWindow.end, options: [])
@@ -226,7 +269,6 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 		)
 
 		let result = try await descriptor.result(for: healthStore)
-		anchorStore.saveAnchor(result.newAnchor, for: .sleepDuration)
 
 		let asleepValues: Set<Int> = [
 			HKCategoryValueSleepAnalysis.asleepCore.rawValue,
@@ -235,7 +277,7 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 			HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue
 		]
 
-		return result.addedSamples
+		let records = result.addedSamples
 			.filter { asleepValues.contains($0.value) }
 			.map { sample in
 				HealthKitBridgeRecord(
@@ -252,6 +294,8 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 					]
 				)
 			}
+
+		return (records: records, anchorCommits: [{ anchorStore.saveAnchor(result.newAnchor, for: .sleepDuration) }])
 	}
 
 	private func incrementalQuantityRecords(
@@ -259,9 +303,9 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 		metric: HealthKitBridgeMetric,
 		dayWindow: DayWindow,
 		unit: HKUnit
-	) async throws -> [HealthKitBridgeRecord] {
+	) async throws -> (records: [HealthKitBridgeRecord], anchorCommits: [() -> Void]) {
 		guard let quantityType = HKObjectType.quantityType(forIdentifier: identifier) else {
-			return []
+			return (records: [], anchorCommits: [])
 		}
 
 		let predicate = HKQuery.predicateForSamples(withStart: dayWindow.start, end: dayWindow.end, options: [])
@@ -272,9 +316,8 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 		)
 
 		let result = try await descriptor.result(for: healthStore)
-		anchorStore.saveAnchor(result.newAnchor, for: metric)
 
-		return result.addedSamples.map { sample in
+		let records = result.addedSamples.map { sample in
 			HealthKitBridgeRecord(
 				id: sample.uuid.uuidString,
 				recordedAt: iso8601Formatter.string(from: sample.endDate),
@@ -289,6 +332,8 @@ struct HealthKitBundleExporter: HealthKitBundleExporting {
 				]
 			)
 		}
+
+		return (records: records, anchorCommits: [{ anchorStore.saveAnchor(result.newAnchor, for: metric) }])
 	}
 }
 

--- a/apps/ios-companion/README.md
+++ b/apps/ios-companion/README.md
@@ -12,7 +12,7 @@ Scope:
   - `resting-heart-rate`
 - support two export paths:
   - `Daily snapshot`
-  - `Changes since last export`
+  - `Today changes since last sync`
 
 The generated bundle matches the web bridge contract in:
 
@@ -23,7 +23,7 @@ The generated bundle matches the web bridge contract in:
 Current query approach:
 
 - snapshot exports use Swift-concurrency HealthKit descriptors for one-shot reads
-- incremental exports use anchored object query descriptors so the app can export only new samples after the previous export
+- incremental exports use anchored object query descriptors so the app can export only new matching samples from today after the previous successful local sync
 
 Why:
 
@@ -49,6 +49,6 @@ This scaffold uses XcodeGen so the repo can hold source and target config withou
 ## Handoff flow
 
 1. Tap `Request Health Access`.
-2. Tap `Export Today Bundle`.
+2. Tap `Export Today Bundle` and confirm the app found at least one matching HealthKit record.
 3. Share the JSON file out of the app.
 4. Paste the JSON into `/imports` in the web app and commit it.

--- a/apps/ios-companion/Tests/HealthCockpitCompanionTests/BridgeBundleEncodingTests.swift
+++ b/apps/ios-companion/Tests/HealthCockpitCompanionTests/BridgeBundleEncodingTests.swift
@@ -31,6 +31,11 @@ final class BridgeBundleEncodingTests: XCTestCase {
 		XCTAssertTrue(json.contains("\"deviceName\" : \"Pyro iPhone\""))
 	}
 
+
+	func testEmptyBundleExportErrorMessageIsExplicit() {
+		XCTAssertEqual(HealthKitBundleExportError.emptyBundle.errorDescription, "No matching HealthKit samples were available for this export.")
+	}
+
 	func testBundleWriterGeneratesStableFilename() throws {
 		let bundle = HealthKitBridgeBundle.make(
 			deviceId: "iphone-15-pro",

--- a/apps/ios-companion/ViewModels/CompanionViewModel.swift
+++ b/apps/ios-companion/ViewModels/CompanionViewModel.swift
@@ -53,10 +53,11 @@ final class CompanionViewModel: ObservableObject {
 		exportState = .exporting
 
 		do {
-			let bundle = try await exporter.exportBundle(for: .now, mode: exportMode)
-			exportURL = try writer.write(bundle)
-			previewJSON = try writer.encodedJSON(for: bundle)
-			lastSummary = "Exported \(bundle.records.count) records from \(bundle.deviceName) using \(exportMode.title.lowercased())."
+			let exportResult = try await exporter.exportBundle(for: .now, mode: exportMode)
+			exportURL = try writer.write(exportResult.bundle)
+			exportResult.commitAnchors()
+			previewJSON = try writer.encodedJSON(for: exportResult.bundle)
+			lastSummary = "Exported \(exportResult.bundle.records.count) records from \(exportResult.bundle.deviceName) using \(exportMode.title.lowercased())."
 			exportState = .ready
 		} catch {
 			exportState = .failed(error.localizedDescription)

--- a/src/lib/core/domain/external-sources.ts
+++ b/src/lib/core/domain/external-sources.ts
@@ -1,0 +1,264 @@
+export const externalSourceCategories = [
+  'nutrition',
+  'movement',
+  'reference',
+  'import',
+  'environment',
+] as const;
+export type ExternalSourceCategory = (typeof externalSourceCategories)[number];
+
+export const externalSourceAuthModes = ['none', 'api-key', 'oauth2', 'native-consent'] as const;
+export type ExternalSourceAuthMode = (typeof externalSourceAuthModes)[number];
+
+export const externalSourceLicenseClasses = [
+  'public-domain',
+  'community-data',
+  'open-data-sharealike',
+  'standards-docs',
+  'restricted-free',
+] as const;
+export type ExternalSourceLicenseClass = (typeof externalSourceLicenseClasses)[number];
+
+export const externalSourceReliabilityLevels = [
+  'official',
+  'community',
+  'sandbox',
+  'optional',
+] as const;
+export type ExternalSourceReliability = (typeof externalSourceReliabilityLevels)[number];
+
+export const externalSourceProductionPostures = ['adopt', 'optional', 'later', 'avoid'] as const;
+export type ExternalSourceProductionPosture = (typeof externalSourceProductionPostures)[number];
+
+export const externalSourceIds = [
+  'usda-fooddata-central',
+  'open-food-facts',
+  'themealdb',
+  'wger',
+  'rxnorm',
+  'clinical-tables-conditions',
+  'medlineplus-connect',
+  'medlineplus-web-service',
+  'openfda-drug-label',
+  'smart-fhir-sandbox',
+  'healthkit-companion',
+  'health-connect',
+  'blue-button',
+  'airnow',
+  'open-meteo',
+] as const;
+export type ExternalSourceId = (typeof externalSourceIds)[number];
+
+export interface ExternalSourceDefinition {
+  id: ExternalSourceId;
+  sourceName: string;
+  category: ExternalSourceCategory;
+  authMode: ExternalSourceAuthMode;
+  licenseClass: ExternalSourceLicenseClass;
+  reliability: ExternalSourceReliability;
+  cacheTtlHours: number;
+  productionPosture: ExternalSourceProductionPosture;
+}
+
+export const EXTERNAL_SOURCE_REGISTRY: ExternalSourceDefinition[] = [
+  {
+    id: 'usda-fooddata-central',
+    sourceName: 'USDA FoodData Central',
+    category: 'nutrition',
+    authMode: 'api-key',
+    licenseClass: 'public-domain',
+    reliability: 'official',
+    cacheTtlHours: 24,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'open-food-facts',
+    sourceName: 'Open Food Facts',
+    category: 'nutrition',
+    authMode: 'none',
+    licenseClass: 'community-data',
+    reliability: 'community',
+    cacheTtlHours: 24,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'themealdb',
+    sourceName: 'TheMealDB',
+    category: 'nutrition',
+    authMode: 'none',
+    licenseClass: 'restricted-free',
+    reliability: 'optional',
+    cacheTtlHours: 24,
+    productionPosture: 'optional',
+  },
+  {
+    id: 'wger',
+    sourceName: 'wger',
+    category: 'movement',
+    authMode: 'none',
+    licenseClass: 'open-data-sharealike',
+    reliability: 'official',
+    cacheTtlHours: 24,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'rxnorm',
+    sourceName: 'RxNorm',
+    category: 'reference',
+    authMode: 'none',
+    licenseClass: 'public-domain',
+    reliability: 'official',
+    cacheTtlHours: 24,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'clinical-tables-conditions',
+    sourceName: 'Clinical Tables Conditions',
+    category: 'reference',
+    authMode: 'none',
+    licenseClass: 'public-domain',
+    reliability: 'official',
+    cacheTtlHours: 24,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'medlineplus-connect',
+    sourceName: 'MedlinePlus Connect',
+    category: 'reference',
+    authMode: 'none',
+    licenseClass: 'restricted-free',
+    reliability: 'official',
+    cacheTtlHours: 24,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'medlineplus-web-service',
+    sourceName: 'MedlinePlus Web Service',
+    category: 'reference',
+    authMode: 'none',
+    licenseClass: 'restricted-free',
+    reliability: 'official',
+    cacheTtlHours: 24,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'openfda-drug-label',
+    sourceName: 'openFDA Drug Label',
+    category: 'reference',
+    authMode: 'api-key',
+    licenseClass: 'public-domain',
+    reliability: 'official',
+    cacheTtlHours: 24,
+    productionPosture: 'optional',
+  },
+  {
+    id: 'smart-fhir-sandbox',
+    sourceName: 'SMART on FHIR sandbox',
+    category: 'import',
+    authMode: 'oauth2',
+    licenseClass: 'standards-docs',
+    reliability: 'sandbox',
+    cacheTtlHours: 1,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'healthkit-companion',
+    sourceName: 'HealthKit Companion',
+    category: 'import',
+    authMode: 'native-consent',
+    licenseClass: 'restricted-free',
+    reliability: 'official',
+    cacheTtlHours: 1,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'health-connect',
+    sourceName: 'Health Connect',
+    category: 'import',
+    authMode: 'native-consent',
+    licenseClass: 'restricted-free',
+    reliability: 'official',
+    cacheTtlHours: 1,
+    productionPosture: 'adopt',
+  },
+  {
+    id: 'blue-button',
+    sourceName: 'Blue Button 2.0',
+    category: 'import',
+    authMode: 'oauth2',
+    licenseClass: 'restricted-free',
+    reliability: 'sandbox',
+    cacheTtlHours: 1,
+    productionPosture: 'later',
+  },
+  {
+    id: 'airnow',
+    sourceName: 'AirNow',
+    category: 'environment',
+    authMode: 'api-key',
+    licenseClass: 'restricted-free',
+    reliability: 'official',
+    cacheTtlHours: 6,
+    productionPosture: 'optional',
+  },
+  {
+    id: 'open-meteo',
+    sourceName: 'Open-Meteo',
+    category: 'environment',
+    authMode: 'none',
+    licenseClass: 'restricted-free',
+    reliability: 'official',
+    cacheTtlHours: 6,
+    productionPosture: 'optional',
+  },
+];
+
+const EXTERNAL_SOURCE_REGISTRY_BY_ID = new Map(
+  EXTERNAL_SOURCE_REGISTRY.map((entry) => [entry.id, entry] as const)
+);
+
+export function getExternalSourceDefinition(sourceId: ExternalSourceId): ExternalSourceDefinition {
+  const definition = EXTERNAL_SOURCE_REGISTRY_BY_ID.get(sourceId);
+  if (!definition) {
+    throw new Error(`Unknown external source: ${sourceId}`);
+  }
+
+  return definition;
+}
+
+export type ExternalSourceCacheStatus = 'local-cache' | 'remote-live' | 'none';
+export type ExternalSourceDegradationStatus = 'none' | 'degraded' | 'local-only';
+
+export interface ExternalSourceProvenance {
+  sourceId: ExternalSourceId;
+  sourceName: string;
+  category: ExternalSourceCategory;
+  productionPosture: ExternalSourceProductionPosture;
+}
+
+export interface ExternalSourceMetadata {
+  provenance: ExternalSourceProvenance[];
+  cacheStatus: ExternalSourceCacheStatus;
+  degradationStatus: ExternalSourceDegradationStatus;
+}
+
+export function createExternalSourceMetadata(
+  sourceId: ExternalSourceId,
+  cacheStatus: ExternalSourceCacheStatus,
+  degradationStatus: ExternalSourceDegradationStatus
+): ExternalSourceMetadata {
+  const definition = getExternalSourceDefinition(sourceId);
+
+  return {
+    provenance: [
+      {
+        sourceId: definition.id,
+        sourceName: definition.sourceName,
+        category: definition.category,
+        productionPosture: definition.productionPosture,
+      },
+    ],
+    cacheStatus,
+    degradationStatus,
+  };
+}

--- a/src/lib/core/domain/types.ts
+++ b/src/lib/core/domain/types.ts
@@ -238,6 +238,7 @@ export interface SymptomHealthEventPayload {
   symptom: string;
   severity: number;
   note?: string;
+  referenceUrl?: string;
 }
 
 export interface AnxietyHealthEventPayload {
@@ -263,6 +264,7 @@ export interface TemplateDoseHealthEventPayload {
   amount?: number;
   unit?: string;
   note?: string;
+  referenceUrl?: string;
 }
 
 export type ManualHealthEventPayload =
@@ -284,6 +286,7 @@ export interface HealthTemplate extends BaseRecord {
   defaultDose?: number;
   defaultUnit?: string;
   note?: string;
+  referenceUrl?: string;
   archived?: boolean;
 }
 
@@ -336,6 +339,16 @@ export interface ImportBatch extends BaseRecord {
   sourceType: ImportSourceType;
   status: 'staged' | 'committed' | 'failed';
   summary?: {
+    adds: number;
+    duplicates: number;
+    warnings: number;
+  };
+}
+
+export interface ImportPreviewResult {
+  sourceType: ImportSourceType;
+  status: 'preview';
+  summary: {
     adds: number;
     duplicates: number;
     warnings: number;

--- a/src/lib/core/shared/external-links.ts
+++ b/src/lib/core/shared/external-links.ts
@@ -1,0 +1,16 @@
+export function toSafeExternalHref(url: string | undefined | null): string | null {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeSafeExternalUrl(url: string | undefined | null): string | undefined {
+  return toSafeExternalHref(url) ?? undefined;
+}

--- a/src/lib/core/ui/route-runtime.ts
+++ b/src/lib/core/ui/route-runtime.ts
@@ -15,7 +15,7 @@ function reportUnhandledRouteError(error: unknown): void {
   }
 
   setTimeout(() => {
-    throw (error instanceof Error ? error : new Error(String(error)));
+    throw error instanceof Error ? error : new Error(String(error));
   }, 0);
 }
 

--- a/src/lib/core/ui/route-runtime.ts
+++ b/src/lib/core/ui/route-runtime.ts
@@ -8,6 +8,17 @@ function isDatabaseClosedError(error: unknown): boolean {
   );
 }
 
+function reportUnhandledRouteError(error: unknown): void {
+  if (typeof globalThis.reportError === 'function') {
+    globalThis.reportError(error);
+    return;
+  }
+
+  setTimeout(() => {
+    throw (error instanceof Error ? error : new Error(String(error)));
+  }, 0);
+}
+
 export function onBrowserRouteMount(run: () => void | (() => void) | Promise<void>): void {
   onMount(() => {
     if (!browser) return;
@@ -17,7 +28,7 @@ export function onBrowserRouteMount(run: () => void | (() => void) | Promise<voi
     }
     void Promise.resolve(result).catch((error) => {
       if (!isDatabaseClosedError(error)) {
-        throw error;
+        reportUnhandledRouteError(error);
       }
     });
   });

--- a/src/lib/features/assessments/Page.svelte
+++ b/src/lib/features/assessments/Page.svelte
@@ -21,8 +21,20 @@
   let assessmentDefinition = $derived(renderAssessment(page.instrument));
   let latestResultRows = $derived(createAssessmentResultRows(page.latest));
 
+  function assessmentsActionErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Unable to reach assessments right now.';
+  }
+
   async function loadLatest() {
-    page = await loadAssessmentsPage(page);
+    try {
+      page = await loadAssessmentsPage(page);
+    } catch (error) {
+      page = {
+        ...page,
+        loading: false,
+        validationError: assessmentsActionErrorMessage(error),
+      };
+    }
   }
 
   function setResponse(index: number, value: string) {
@@ -33,11 +45,25 @@
   }
 
   async function saveProgress() {
-    page = await saveAssessmentsProgressPage(page);
+    try {
+      page = await saveAssessmentsProgressPage(page);
+    } catch (error) {
+      page = {
+        ...page,
+        validationError: assessmentsActionErrorMessage(error),
+      };
+    }
   }
 
   async function saveAssessment() {
-    page = await submitAssessmentsPage(page);
+    try {
+      page = await submitAssessmentsPage(page);
+    } catch (error) {
+      page = {
+        ...page,
+        validationError: assessmentsActionErrorMessage(error),
+      };
+    }
   }
 
   onBrowserRouteMount(loadLatest);

--- a/src/lib/features/health/Page.svelte
+++ b/src/lib/features/health/Page.svelte
@@ -14,12 +14,28 @@
     saveSleepNotePage,
     saveSymptomPage,
     saveTemplatePage,
+    searchHealthMedicationSuggestions,
+    searchHealthSymptomSuggestions,
   } from './client';
-  import { createHealthEventRows, createSleepCardLines } from './model';
+  import {
+    createHealthEventRows,
+    createSleepCardLines,
+    type HealthMedicationSuggestion,
+    type HealthSymptomSuggestion,
+    updateSymptomFormValue,
+    updateTemplateFormValue,
+  } from './model';
+  import type { ExternalSourceMetadata } from '$lib/core/domain/external-sources';
 
   let page = $state(createHealthPageState());
   let eventRows = $derived(createHealthEventRows(page.snapshot?.events ?? []));
   let sleepCardLines = $derived(createSleepCardLines(page.snapshot));
+  let symptomSuggestions = $state<HealthSymptomSuggestion[]>([]);
+  let symptomSuggestionNotice = $state('');
+  let symptomSuggestionMetadata = $state<ExternalSourceMetadata | null>(null);
+  let medicationSuggestions = $state<HealthMedicationSuggestion[]>([]);
+  let medicationSuggestionNotice = $state('');
+  let medicationSuggestionMetadata = $state<ExternalSourceMetadata | null>(null);
 
   async function loadSnapshot() {
     page = await loadHealthPage();
@@ -85,11 +101,11 @@
   function updateSymptomField(field: keyof typeof page.symptomForm, value: string) {
     page = {
       ...page,
-      symptomForm: {
-        ...page.symptomForm,
-        [field]: value,
-      },
+      symptomForm: updateSymptomFormValue(page.symptomForm, field, value),
     };
+    symptomSuggestions = [];
+    symptomSuggestionNotice = '';
+    symptomSuggestionMetadata = null;
   }
 
   function updateAnxietyField(field: keyof typeof page.anxietyForm, value: string) {
@@ -115,11 +131,55 @@
   function updateTemplateField(field: keyof typeof page.templateForm, value: string) {
     page = {
       ...page,
-      templateForm: {
-        ...page.templateForm,
-        [field]: value,
+      templateForm: updateTemplateFormValue(page.templateForm, field, value),
+    };
+    medicationSuggestions = [];
+    medicationSuggestionNotice = '';
+    medicationSuggestionMetadata = null;
+  }
+
+  async function searchSymptomSuggestions() {
+    const response = await searchHealthSymptomSuggestions(page.symptomForm.symptom);
+    symptomSuggestions = response.suggestions;
+    symptomSuggestionNotice =
+      response.notice || (page.symptomForm.symptom.trim() ? 'No symptom suggestions found.' : '');
+    symptomSuggestionMetadata = response.metadata;
+  }
+
+  function applySymptomSuggestion(suggestion: HealthSymptomSuggestion) {
+    page = {
+      ...page,
+      symptomForm: {
+        ...page.symptomForm,
+        symptom: suggestion.label,
+        referenceUrl: suggestion.referenceUrl ?? '',
       },
     };
+    symptomSuggestions = [];
+    symptomSuggestionNotice = '';
+    symptomSuggestionMetadata = null;
+  }
+
+  async function searchMedicationSuggestions() {
+    const response = await searchHealthMedicationSuggestions(page.templateForm.label);
+    medicationSuggestions = response.suggestions;
+    medicationSuggestionNotice =
+      response.notice || (page.templateForm.label.trim() ? 'No medication suggestions found.' : '');
+    medicationSuggestionMetadata = response.metadata;
+  }
+
+  function applyMedicationSuggestion(suggestion: HealthMedicationSuggestion) {
+    page = {
+      ...page,
+      templateForm: {
+        ...page.templateForm,
+        label: suggestion.label,
+        referenceUrl: suggestion.referenceUrl ?? '',
+      },
+    };
+    medicationSuggestions = [];
+    medicationSuggestionNotice = '';
+    medicationSuggestionMetadata = null;
   }
 
   onBrowserRouteMount(loadSnapshot);
@@ -143,6 +203,9 @@
 
     <HealthManualLoggingSection
       symptomForm={page.symptomForm}
+      {symptomSuggestions}
+      {symptomSuggestionNotice}
+      {symptomSuggestionMetadata}
       anxietyForm={page.anxietyForm}
       sleepNoteForm={page.sleepNoteForm}
       onSymptomFieldChange={updateSymptomField}
@@ -151,14 +214,21 @@
       onSaveSymptom={saveSymptom}
       onSaveAnxiety={saveAnxiety}
       onSaveSleepNote={saveSleepNote}
+      onSearchSymptomSuggestions={searchSymptomSuggestions}
+      onApplySymptomSuggestion={applySymptomSuggestion}
     />
 
     <HealthTemplateSection
       templateForm={page.templateForm}
       templates={page.snapshot?.templates ?? []}
+      {medicationSuggestions}
+      {medicationSuggestionNotice}
+      {medicationSuggestionMetadata}
       onTemplateFieldChange={updateTemplateField}
       onSaveTemplate={saveTemplate}
       onQuickLogTemplate={quickLogTemplate}
+      onSearchMedicationSuggestions={searchMedicationSuggestions}
+      onApplyMedicationSuggestion={applyMedicationSuggestion}
     />
 
     <HealthEventStreamSection {eventRows} />

--- a/src/lib/features/health/actions.ts
+++ b/src/lib/features/health/actions.ts
@@ -58,6 +58,7 @@ export async function saveSymptomPage(
     symptom: state.symptomForm.symptom,
     severity: Number(state.symptomForm.severity),
     note: state.symptomForm.note,
+    referenceUrl: state.symptomForm.referenceUrl,
   });
   return await refreshHealthPageAfterMutation(store, state, {
     saveNotice: 'Symptom logged.',
@@ -122,6 +123,7 @@ export async function saveTemplatePage(
     defaultDose: parseOptionalNumber(state.templateForm.defaultDose),
     defaultUnit: state.templateForm.defaultUnit,
     note: state.templateForm.note,
+    referenceUrl: state.templateForm.referenceUrl,
   });
   return await refreshHealthPageAfterMutation(store, state, {
     saveNotice: 'Template saved.',

--- a/src/lib/features/health/client.ts
+++ b/src/lib/features/health/client.ts
@@ -1,5 +1,8 @@
 import { currentLocalDay } from '$lib/core/domain/time';
-import { createFeatureActionClient, createFeatureRequestClient } from '$lib/core/http/feature-client';
+import {
+  createFeatureActionClient,
+  createFeatureRequestClient,
+} from '$lib/core/http/feature-client';
 import {
   createHealthPageState,
   loadHealthPage as loadHealthPageController,
@@ -69,15 +72,18 @@ export async function quickLogTemplatePage(
 export async function searchHealthSymptomSuggestions(
   query: string
 ): Promise<HealthSymptomSuggestionResponse> {
-  return await symptomSearchClient.request<HealthSymptomSuggestionResponse>({ query }, async () => ({
-    suggestions: [] satisfies HealthSymptomSuggestion[],
-    notice: '',
-    metadata: {
-      provenance: [],
-      cacheStatus: 'none',
-      degradationStatus: 'none',
-    },
-  }));
+  return await symptomSearchClient.request<HealthSymptomSuggestionResponse>(
+    { query },
+    async () => ({
+      suggestions: [] satisfies HealthSymptomSuggestion[],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    })
+  );
 }
 
 export async function searchHealthMedicationSuggestions(

--- a/src/lib/features/health/client.ts
+++ b/src/lib/features/health/client.ts
@@ -1,5 +1,5 @@
 import { currentLocalDay } from '$lib/core/domain/time';
-import { createFeatureActionClient } from '$lib/core/http/feature-client';
+import { createFeatureActionClient, createFeatureRequestClient } from '$lib/core/http/feature-client';
 import {
   createHealthPageState,
   loadHealthPage as loadHealthPageController,
@@ -13,10 +13,16 @@ import {
   saveTemplatePage as saveTemplatePageController,
   type HealthActionsStorage,
 } from './actions';
+import type { HealthSymptomSuggestion } from './model';
+import type { HealthSymptomSuggestionResponse } from '$lib/server/health/clinical-tables';
+import type { HealthMedicationSuggestion } from './model';
+import type { HealthMedicationSuggestionResponse } from '$lib/server/health/rxnorm';
 
 export { createHealthPageState };
 
 const healthClient = createFeatureActionClient<HealthActionsStorage>('/api/health');
+const symptomSearchClient = createFeatureRequestClient<never>('/api/health/search-symptoms');
+const medicationSearchClient = createFeatureRequestClient<never>('/api/health/search-medications');
 
 export async function loadHealthPage(localDay = currentLocalDay()): Promise<HealthPageState> {
   return await healthClient.action('load', (db) => loadHealthPageController(db, localDay), {
@@ -57,5 +63,36 @@ export async function quickLogTemplatePage(
     state,
     (db) => quickLogTemplatePageController(db, state, templateId),
     { templateId }
+  );
+}
+
+export async function searchHealthSymptomSuggestions(
+  query: string
+): Promise<HealthSymptomSuggestionResponse> {
+  return await symptomSearchClient.request<HealthSymptomSuggestionResponse>({ query }, async () => ({
+    suggestions: [] satisfies HealthSymptomSuggestion[],
+    notice: '',
+    metadata: {
+      provenance: [],
+      cacheStatus: 'none',
+      degradationStatus: 'none',
+    },
+  }));
+}
+
+export async function searchHealthMedicationSuggestions(
+  query: string
+): Promise<HealthMedicationSuggestionResponse> {
+  return await medicationSearchClient.request<HealthMedicationSuggestionResponse>(
+    { query },
+    async () => ({
+      suggestions: [] satisfies HealthMedicationSuggestion[],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    })
   );
 }

--- a/src/lib/features/health/components/HealthEventStreamSection.svelte
+++ b/src/lib/features/health/components/HealthEventStreamSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { toSafeExternalHref } from '$lib/core/shared/external-links';
   import { EmptyState, SectionCard } from '$lib/core/ui/primitives';
   import type { HealthEventRow } from '$lib/features/health/model';
 
@@ -19,6 +20,19 @@
             {#each event.lines as line (line)}
               <p>{line}</p>
             {/each}
+            {#if toSafeExternalHref(event.referenceUrl)}
+              <p>
+                <a
+                  class="status-copy"
+                  href={toSafeExternalHref(event.referenceUrl) ?? undefined}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Learn more about logged medication ${event.title}`}
+                >
+                  Learn more
+                </a>
+              </p>
+            {/if}
             <p class="status-copy event-meta">{event.meta}</p>
           </div>
           {#if event.badge}

--- a/src/lib/features/health/components/HealthManualLoggingSection.svelte
+++ b/src/lib/features/health/components/HealthManualLoggingSection.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
+  import type { ExternalSourceMetadata } from '$lib/core/domain/external-sources';
+  import { toSafeExternalHref } from '$lib/core/shared/external-links';
   import { Button, Field, SectionCard, StatusBanner } from '$lib/core/ui/primitives';
   import type {
     AnxietyFormState,
+    HealthSymptomSuggestion,
     SleepNoteFormState,
     SymptomFormState,
   } from '$lib/features/health/model';
 
   let {
     symptomForm,
+    symptomSuggestions,
+    symptomSuggestionNotice,
+    symptomSuggestionMetadata,
     anxietyForm,
     sleepNoteForm,
     onSymptomFieldChange,
@@ -16,8 +22,13 @@
     onSaveSymptom,
     onSaveAnxiety,
     onSaveSleepNote,
+    onSearchSymptomSuggestions,
+    onApplySymptomSuggestion,
   }: {
     symptomForm: SymptomFormState;
+    symptomSuggestions: HealthSymptomSuggestion[];
+    symptomSuggestionNotice: string;
+    symptomSuggestionMetadata: ExternalSourceMetadata | null;
     anxietyForm: AnxietyFormState;
     sleepNoteForm: SleepNoteFormState;
     onSymptomFieldChange: (field: keyof SymptomFormState, value: string) => void;
@@ -26,7 +37,24 @@
     onSaveSymptom: () => void;
     onSaveAnxiety: () => void;
     onSaveSleepNote: () => void;
+    onSearchSymptomSuggestions: () => void;
+    onApplySymptomSuggestion: (suggestion: HealthSymptomSuggestion) => void;
   } = $props();
+
+  function createMetadataRows(metadata: ExternalSourceMetadata | null): string[] {
+    if (!metadata) {
+      return [];
+    }
+
+    const sourceNames = metadata.provenance.map((item) => item.sourceName).join(', ');
+
+    return [
+      sourceNames ? `Sources: ${sourceNames}` : '',
+      `Cache: ${metadata.cacheStatus}`,
+      `Status: ${metadata.degradationStatus}`,
+    ].filter(Boolean);
+  }
+
 </script>
 
 <SectionCard title="Log symptom">
@@ -66,7 +94,53 @@
   </div>
   <div class="button-row">
     <Button onclick={onSaveSymptom}>Log symptom</Button>
+    <Button variant="ghost" onclick={onSearchSymptomSuggestions}>Suggest symptoms</Button>
   </div>
+  {#if symptomSuggestionNotice}
+    <p class="status-copy">{symptomSuggestionNotice}</p>
+  {/if}
+  {#if symptomSuggestionMetadata}
+    <div class="metadata-block">
+      {#each createMetadataRows(symptomSuggestionMetadata) as row (row)}
+        <p class="status-copy">{row}</p>
+      {/each}
+    </div>
+  {/if}
+  {#if symptomSuggestions.length}
+    <ul class="entry-list linked-context-list">
+      {#each symptomSuggestions as suggestion (suggestion.label)}
+        <li>
+          <div>
+            <strong>{suggestion.label}</strong>
+            {#if suggestion.code}
+              <p>{suggestion.code}</p>
+            {/if}
+          </div>
+          <div class="context-actions">
+            <span class="status-copy">{suggestion.sourceName}</span>
+            {#if toSafeExternalHref(suggestion.referenceUrl)}
+              <a
+                class="status-copy"
+                href={toSafeExternalHref(suggestion.referenceUrl) ?? undefined}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`Learn more about ${suggestion.label}`}
+              >
+                Learn more
+              </a>
+            {/if}
+            <Button
+              variant="ghost"
+              aria-label={`Use symptom ${suggestion.label}`}
+              onclick={() => onApplySymptomSuggestion(suggestion)}
+            >
+              Use symptom
+            </Button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
 </SectionCard>
 
 <SectionCard title="Log anxiety episode">
@@ -171,5 +245,9 @@
 <style>
   .spaced-field {
     margin-top: 0.9rem;
+  }
+
+  .metadata-block {
+    margin-top: 0.35rem;
   }
 </style>

--- a/src/lib/features/health/components/HealthManualLoggingSection.svelte
+++ b/src/lib/features/health/components/HealthManualLoggingSection.svelte
@@ -54,7 +54,6 @@
       `Status: ${metadata.degradationStatus}`,
     ].filter(Boolean);
   }
-
 </script>
 
 <SectionCard title="Log symptom">

--- a/src/lib/features/health/components/HealthTemplateSection.svelte
+++ b/src/lib/features/health/components/HealthTemplateSection.svelte
@@ -46,7 +46,6 @@
       `Status: ${metadata.degradationStatus}`,
     ].filter(Boolean);
   }
-
 </script>
 
 <SectionCard title="Medication and supplement templates">

--- a/src/lib/features/health/components/HealthTemplateSection.svelte
+++ b/src/lib/features/health/components/HealthTemplateSection.svelte
@@ -1,21 +1,52 @@
 <script lang="ts">
+  import type { ExternalSourceMetadata } from '$lib/core/domain/external-sources';
+  import { toSafeExternalHref } from '$lib/core/shared/external-links';
   import type { HealthTemplate } from '$lib/core/domain/types';
   import { Button, EmptyState, Field, SectionCard } from '$lib/core/ui/primitives';
-  import { describeHealthTemplate, type TemplateFormState } from '$lib/features/health/model';
+  import {
+    describeHealthTemplate,
+    type HealthMedicationSuggestion,
+    type TemplateFormState,
+  } from '$lib/features/health/model';
 
   let {
     templateForm,
     templates,
+    medicationSuggestions,
+    medicationSuggestionNotice,
+    medicationSuggestionMetadata,
     onTemplateFieldChange,
     onSaveTemplate,
     onQuickLogTemplate,
+    onSearchMedicationSuggestions,
+    onApplyMedicationSuggestion,
   }: {
     templateForm: TemplateFormState;
     templates: HealthTemplate[];
+    medicationSuggestions: HealthMedicationSuggestion[];
+    medicationSuggestionNotice: string;
+    medicationSuggestionMetadata: ExternalSourceMetadata | null;
     onTemplateFieldChange: (field: keyof TemplateFormState, value: string) => void;
     onSaveTemplate: () => void;
     onQuickLogTemplate: (templateId: string) => void;
+    onSearchMedicationSuggestions: () => void;
+    onApplyMedicationSuggestion: (suggestion: HealthMedicationSuggestion) => void;
   } = $props();
+
+  function createMetadataRows(metadata: ExternalSourceMetadata | null): string[] {
+    if (!metadata) {
+      return [];
+    }
+
+    const sourceNames = metadata.provenance.map((item) => item.sourceName).join(', ');
+
+    return [
+      sourceNames ? `Sources: ${sourceNames}` : '',
+      `Cache: ${metadata.cacheStatus}`,
+      `Status: ${metadata.degradationStatus}`,
+    ].filter(Boolean);
+  }
+
 </script>
 
 <SectionCard title="Medication and supplement templates">
@@ -77,7 +108,55 @@
   </div>
   <div class="button-row">
     <Button onclick={onSaveTemplate}>Save template</Button>
+    {#if templateForm.templateType === 'medication'}
+      <Button variant="ghost" onclick={onSearchMedicationSuggestions}>Suggest medications</Button>
+    {/if}
   </div>
+  {#if templateForm.templateType === 'medication' && medicationSuggestionNotice}
+    <p class="status-copy">{medicationSuggestionNotice}</p>
+  {/if}
+  {#if templateForm.templateType === 'medication' && medicationSuggestionMetadata}
+    <div class="metadata-block">
+      {#each createMetadataRows(medicationSuggestionMetadata) as row (row)}
+        <p class="status-copy">{row}</p>
+      {/each}
+    </div>
+  {/if}
+  {#if templateForm.templateType === 'medication' && medicationSuggestions.length}
+    <ul class="template-list spaced-list">
+      {#each medicationSuggestions as suggestion (suggestion.label)}
+        <li>
+          <div>
+            <strong>{suggestion.label}</strong>
+            {#if suggestion.code}
+              <p>{suggestion.code}</p>
+            {/if}
+          </div>
+          <div class="context-actions">
+            <span class="status-copy">{suggestion.sourceName}</span>
+            {#if toSafeExternalHref(suggestion.referenceUrl)}
+              <a
+                class="status-copy"
+                href={toSafeExternalHref(suggestion.referenceUrl) ?? undefined}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`Learn more about ${suggestion.label}`}
+              >
+                Learn more
+              </a>
+            {/if}
+            <Button
+              variant="ghost"
+              aria-label={`Use medication ${suggestion.label}`}
+              onclick={() => onApplyMedicationSuggestion(suggestion)}
+            >
+              Use medication
+            </Button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
 
   {#if templates.length}
     <ul class="template-list spaced-list">
@@ -85,6 +164,21 @@
         <li>
           <div>
             <strong>{template.label}</strong>
+            {#if toSafeExternalHref(template.referenceUrl)}
+              <p>
+                <a
+                  class="status-copy"
+                  href={toSafeExternalHref(template.referenceUrl) ?? undefined}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Learn more about saved ${
+                    template.templateType === 'medication' ? 'medication' : 'supplement'
+                  } ${template.label}`}
+                >
+                  Learn more
+                </a>
+              </p>
+            {/if}
             {#each describeHealthTemplate(template) as line (line)}
               <p>{line}</p>
             {/each}
@@ -120,6 +214,10 @@
     margin-top: 1rem;
   }
 
+  .metadata-block {
+    margin-top: 0.35rem;
+  }
+
   .template-list {
     list-style: none;
     padding: 0;
@@ -144,5 +242,12 @@
   .template-list p {
     margin: 0.25rem 0 0;
     color: var(--phc-muted);
+  }
+
+  .context-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
   }
 </style>

--- a/src/lib/features/health/contracts.ts
+++ b/src/lib/features/health/contracts.ts
@@ -1,30 +1,64 @@
 import { z } from 'zod';
+import { normalizeSafeExternalUrl } from '$lib/core/shared/external-links';
+
+function isFiniteNumberString(value: string): boolean {
+  const parsed = Number(value);
+  return Number.isFinite(parsed);
+}
+
+function isBoundedNumberString(value: string, min: number, max: number): boolean {
+  if (!isFiniteNumberString(value)) {
+    return false;
+  }
+
+  const parsed = Number(value);
+  return parsed >= min && parsed <= max;
+}
+
+const safeReferenceUrlSchema = z
+  .string()
+  .transform((value) => normalizeSafeExternalUrl(value) ?? '');
+
+const scoreStringSchema = z
+  .string()
+  .refine((value) => isBoundedNumberString(value, 1, 5), 'Expected a score from 1 to 5');
+
+const optionalNonNegativeNumberStringSchema = z
+  .string()
+  .refine(
+    (value) => !value.trim() || (isFiniteNumberString(value) && Number(value) >= 0),
+    'Expected a non-negative finite number or blank'
+  );
 
 const symptomFormSchema = z.object({
   symptom: z.string(),
-  severity: z.string(),
+  severity: scoreStringSchema,
   note: z.string(),
+  referenceUrl: safeReferenceUrlSchema,
 });
 
 const anxietyFormSchema = z.object({
-  intensity: z.string(),
+  intensity: scoreStringSchema,
   trigger: z.string(),
-  durationMinutes: z.string(),
+  durationMinutes: optionalNonNegativeNumberStringSchema,
   note: z.string(),
 });
 
 const sleepNoteFormSchema = z.object({
   note: z.string(),
-  restfulness: z.string(),
+  restfulness: z
+    .string()
+    .refine((value) => !value.trim() || isBoundedNumberString(value, 1, 5), 'Expected a score from 1 to 5 or blank'),
   context: z.string(),
 });
 
 const templateFormSchema = z.object({
   label: z.string(),
   templateType: z.enum(['medication', 'supplement']),
-  defaultDose: z.string(),
+  defaultDose: optionalNonNegativeNumberStringSchema,
   defaultUnit: z.string(),
   note: z.string(),
+  referenceUrl: safeReferenceUrlSchema,
 });
 
 export const healthMutationStateSchema = z.object({

--- a/src/lib/features/health/contracts.ts
+++ b/src/lib/features/health/contracts.ts
@@ -48,7 +48,10 @@ const sleepNoteFormSchema = z.object({
   note: z.string(),
   restfulness: z
     .string()
-    .refine((value) => !value.trim() || isBoundedNumberString(value, 1, 5), 'Expected a score from 1 to 5 or blank'),
+    .refine(
+      (value) => !value.trim() || isBoundedNumberString(value, 1, 5),
+      'Expected a score from 1 to 5 or blank'
+    ),
   context: z.string(),
 });
 

--- a/src/lib/features/health/model.ts
+++ b/src/lib/features/health/model.ts
@@ -6,6 +6,7 @@ export const DEFAULT_SYMPTOM_FORM = {
   symptom: '',
   severity: '3',
   note: '',
+  referenceUrl: '',
 } as const;
 
 export const DEFAULT_ANXIETY_FORM = {
@@ -27,6 +28,7 @@ export const DEFAULT_TEMPLATE_FORM = {
   defaultDose: '',
   defaultUnit: '',
   note: '',
+  referenceUrl: '',
 } as const;
 
 export type SymptomFormState = { [Key in keyof typeof DEFAULT_SYMPTOM_FORM]: string };
@@ -38,7 +40,22 @@ export type TemplateFormState = {
   defaultDose: string;
   defaultUnit: string;
   note: string;
+  referenceUrl: string;
 };
+
+export interface HealthSymptomSuggestion {
+  label: string;
+  code?: string;
+  referenceUrl?: string;
+  sourceName: string;
+}
+
+export interface HealthMedicationSuggestion {
+  label: string;
+  code?: string;
+  referenceUrl?: string;
+  sourceName: string;
+}
 
 export interface HealthEventRow {
   id: string;
@@ -46,6 +63,7 @@ export interface HealthEventRow {
   badge?: string;
   lines: string[];
   meta: string;
+  referenceUrl?: string;
 }
 
 export function createSymptomForm(): SymptomFormState {
@@ -62,6 +80,30 @@ export function createSleepNoteForm(): SleepNoteFormState {
 
 export function createTemplateForm(): TemplateFormState {
   return { ...DEFAULT_TEMPLATE_FORM };
+}
+
+export function updateSymptomFormValue(
+  form: SymptomFormState,
+  field: keyof SymptomFormState,
+  value: string
+): SymptomFormState {
+  return {
+    ...form,
+    [field]: value,
+    ...(field === 'symptom' ? { referenceUrl: '' } : {}),
+  };
+}
+
+export function updateTemplateFormValue(
+  form: TemplateFormState,
+  field: keyof TemplateFormState,
+  value: string
+): TemplateFormState {
+  return {
+    ...form,
+    [field]: value,
+    ...(field === 'label' || field === 'templateType' ? { referenceUrl: '' } : {}),
+  } as TemplateFormState;
 }
 
 function formatDose(amount?: number, unit?: string): string | null {
@@ -124,6 +166,10 @@ function buildManualHealthRow(event: HealthEvent): HealthEventRow {
       badge: severity,
       lines: compactLines([typeof payload.note === 'string' ? payload.note : undefined]),
       meta,
+      referenceUrl:
+        typeof payload.referenceUrl === 'string' && payload.referenceUrl.trim().length > 0
+          ? payload.referenceUrl
+          : undefined,
     };
   }
 
@@ -182,6 +228,10 @@ function buildManualHealthRow(event: HealthEvent): HealthEventRow {
         typeof payload.note === 'string' ? payload.note : undefined,
       ]),
       meta,
+      referenceUrl:
+        typeof payload.referenceUrl === 'string' && payload.referenceUrl.trim().length > 0
+          ? payload.referenceUrl
+          : undefined,
     };
   }
 

--- a/src/lib/features/health/service.ts
+++ b/src/lib/features/health/service.ts
@@ -4,6 +4,7 @@ import {
   isHealthMetricVisibleOnSurface,
   matchesHealthMetric,
 } from '$lib/core/domain/health-metrics';
+import { normalizeSafeExternalUrl } from '$lib/core/shared/external-links';
 import type {
   AnxietyHealthEventPayload,
   HealthEvent,
@@ -38,6 +39,7 @@ export interface SymptomLogInput {
   symptom: string;
   severity: number;
   note?: string;
+  referenceUrl?: string;
 }
 
 export interface AnxietyLogInput {
@@ -61,6 +63,7 @@ export interface CreateHealthTemplateInput {
   defaultDose?: number;
   defaultUnit?: string;
   note?: string;
+  referenceUrl?: string;
 }
 
 export interface HealthSnapshot {
@@ -189,6 +192,7 @@ export function buildHealthTemplateRecord(
   const normalizedLabel = input.label.trim();
   const normalizedUnit = normalizeOptionalText(input.defaultUnit);
   const normalizedNote = normalizeOptionalText(input.note);
+  const normalizedReferenceUrl = normalizeSafeExternalUrl(input.referenceUrl);
   const normalizedDose = normalizeOptionalNumber(input.defaultDose);
 
   return {
@@ -202,6 +206,7 @@ export function buildHealthTemplateRecord(
     defaultDose: normalizedDose,
     defaultUnit: normalizedUnit,
     note: normalizedNote,
+    referenceUrl: normalizedReferenceUrl,
     archived: false,
   };
 }
@@ -215,6 +220,7 @@ export async function logSymptomEvent(
     symptom: input.symptom.trim(),
     severity: input.severity,
     note: normalizeOptionalText(input.note),
+    referenceUrl: normalizeSafeExternalUrl(input.referenceUrl),
   };
 
   const event = buildManualHealthEvent({
@@ -307,6 +313,7 @@ export async function quickLogHealthTemplate(
     amount: template.defaultDose,
     unit: template.defaultUnit,
     note: template.note,
+    referenceUrl: template.referenceUrl,
   };
 
   const eventType: ManualHealthEventType =

--- a/src/lib/features/imports/ImportBatchHistoryCard.svelte
+++ b/src/lib/features/imports/ImportBatchHistoryCard.svelte
@@ -16,6 +16,12 @@
         <li>
           <strong>{batch.sourceType}</strong>
           <span>{batch.status}</span>
+          <p>Updated: {batch.updatedAt.slice(0, 10)}</p>
+          {#if batch.summary}
+            <p>Adds: {batch.summary.adds}</p>
+            <p>Duplicates: {batch.summary.duplicates}</p>
+            <p>Warnings: {batch.summary.warnings}</p>
+          {/if}
         </li>
       {/each}
     </ul>

--- a/src/lib/features/imports/ImportComposerCard.svelte
+++ b/src/lib/features/imports/ImportComposerCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import type { ImportBatch, ImportSourceType } from '$lib/core/domain/types';
+  import type { ImportPreviewResult, ImportSourceType } from '$lib/core/domain/types';
   import type { DeviceSourceManifest } from '$lib/features/integrations/manifests/device-sources';
   import { Button, Field, SectionCard, StatusBanner } from '$lib/core/ui/primitives';
   import ImportPayloadSummaryCard from './ImportPayloadSummaryCard.svelte';
@@ -26,7 +26,7 @@
     showHelperLinks?: boolean;
     currentSampleBundle?: SampleBundle | null;
     canPreviewPayload?: boolean;
-    latestPreview?: ImportBatch | null;
+    latestPreview?: ImportPreviewResult | null;
     saveNotice?: string;
     fileNotice?: string;
     errorNotice?: string;
@@ -136,6 +136,14 @@
     />
   {/if}
 
+  {#if currentSourceConfig.sourceMetadata}
+    <div class="source-metadata soft-panel">
+      <p class="status-copy">Source: {currentSourceConfig.sourceMetadata.sourceName}</p>
+      <p class="status-copy">Trust: {currentSourceConfig.sourceMetadata.reliability}</p>
+      <p class="status-copy">Auth: {currentSourceConfig.sourceMetadata.authMode}</p>
+    </div>
+  {/if}
+
   {#if currentHelperCopy}
     <div class="helper-copy soft-panel">
       <p><strong>{currentHelperCopy.title}</strong></p>
@@ -176,7 +184,7 @@
     <Button variant="secondary" onclick={onPreview} disabled={!canPreviewPayload}>
       Preview import
     </Button>
-    <Button onclick={onCommit} disabled={!latestPreview || latestPreview.status === 'committed'}>
+    <Button onclick={onCommit} disabled={!latestPreview}>
       Commit import
     </Button>
   </div>
@@ -212,7 +220,12 @@
     margin: 0 0 1rem;
   }
 
+  .source-metadata {
+    margin: 0 0 1rem;
+  }
+
   .helper-copy p,
+  .source-metadata p,
   .helper-copy ul {
     margin: 0;
   }

--- a/src/lib/features/imports/ImportComposerCard.svelte
+++ b/src/lib/features/imports/ImportComposerCard.svelte
@@ -184,9 +184,7 @@
     <Button variant="secondary" onclick={onPreview} disabled={!canPreviewPayload}>
       Preview import
     </Button>
-    <Button onclick={onCommit} disabled={!latestPreview}>
-      Commit import
-    </Button>
+    <Button onclick={onCommit} disabled={!latestPreview}>Commit import</Button>
   </div>
 
   {#if latestPreview}

--- a/src/lib/features/imports/Page.svelte
+++ b/src/lib/features/imports/Page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ImportBatch, ImportSourceType } from '$lib/core/domain/types';
+  import type { ImportBatch, ImportPreviewResult, ImportSourceType } from '$lib/core/domain/types';
   import { DEVICE_SOURCE_MANIFESTS } from '$lib/features/integrations/manifests/device-sources';
   import { createSampleHealthKitBundle } from '$lib/features/integrations/connectors/healthkit';
   import { createSampleSmartFhirBundle } from '$lib/features/integrations/connectors/smart-fhir';
@@ -51,7 +51,7 @@
   let fileNotice = $state(initialPageState.intake.fileNotice);
   let payloadSummary = $state(initialPageState.intake.payloadSummary);
   let isManualAnalysisPending = $state(initialPageState.intake.isManualAnalysisPending);
-  let latestPreview = $state<ImportBatch | null>(initialPageState.intake.latestPreview);
+  let latestPreview = $state<ImportPreviewResult | null>(initialPageState.intake.latestPreview);
   let saveNotice = $state(initialPageState.intake.saveNotice);
   let errorNotice = $state(initialPageState.intake.errorNotice);
   let batches = $state<ImportBatch[]>(initialPageState.batches);
@@ -147,6 +147,7 @@
 
   async function commitPreview() {
     const nextState = await commitImportsPage(readPageState(), {
+      getOwnerProfile,
       commitImportBatch: commitImportBatchClient,
     });
 

--- a/src/lib/features/imports/client.ts
+++ b/src/lib/features/imports/client.ts
@@ -1,6 +1,7 @@
 import type { ImportBatch, ImportSourceType, OwnerProfile } from '$lib/core/domain/types';
 import { createFeatureActionClient } from '$lib/core/http/feature-client';
 import { commitImportBatch, listImportBatches, previewImport } from './store';
+import type { ImportPreviewResult } from '$lib/core/domain/types';
 
 const importsClient =
   createFeatureActionClient<Parameters<typeof previewImport>[0]>('/api/imports');
@@ -13,10 +14,14 @@ export async function previewImportClient(input: {
   sourceType: ImportSourceType;
   rawText: string;
   ownerProfile?: OwnerProfile | null;
-}): Promise<ImportBatch> {
+}): Promise<ImportPreviewResult> {
   return await importsClient.action('preview', (db) => previewImport(db, input), { input });
 }
 
-export async function commitImportBatchClient(batchId: string): Promise<ImportBatch> {
-  return await importsClient.action('commit', (db) => commitImportBatch(db, batchId), { batchId });
+export async function commitImportBatchClient(input: {
+  sourceType: ImportSourceType;
+  rawText: string;
+  ownerProfile?: OwnerProfile | null;
+}): Promise<ImportBatch> {
+  return await importsClient.action('commit', (db) => commitImportBatch(db, input), { input });
 }

--- a/src/lib/features/imports/contracts.ts
+++ b/src/lib/features/imports/contracts.ts
@@ -20,7 +20,7 @@ export const importsRequestSchema = z.discriminatedUnion('action', [
   }),
   z.object({
     action: z.literal('commit'),
-    batchId: z.string(),
+    input: importPreviewInputSchema,
   }),
 ]);
 

--- a/src/lib/features/imports/intake-state.ts
+++ b/src/lib/features/imports/intake-state.ts
@@ -1,4 +1,4 @@
-import type { ImportBatch, ImportSourceType } from '$lib/core/domain/types';
+import type { ImportBatch, ImportPreviewResult, ImportSourceType } from '$lib/core/domain/types';
 import type { ImportPayloadSummary } from './core';
 
 export type PayloadOrigin = 'manual' | 'file' | 'sample';
@@ -11,7 +11,7 @@ export interface ImportIntakeState {
   fileNotice: string;
   payloadSummary: ImportPayloadSummary | null;
   isManualAnalysisPending: boolean;
-  latestPreview: ImportBatch | null;
+  latestPreview: ImportPreviewResult | null;
   saveNotice: string;
   errorNotice: string;
 }
@@ -146,7 +146,7 @@ export function clearLoadedPayloadState(state: ImportIntakeState): ImportIntakeS
 
 export function applyPreviewSuccessState(
   state: ImportIntakeState,
-  latestPreview: ImportBatch
+  latestPreview: ImportPreviewResult
 ): ImportIntakeState {
   return clearFeedbackState(state, { latestPreview });
 }
@@ -160,7 +160,7 @@ export function applyPreviewErrorState(
 
 export function applyCommitSuccessState(
   state: ImportIntakeState,
-  latestPreview: ImportBatch,
+  latestPreview: ImportPreviewResult | null,
   saveNotice = 'Import committed.'
 ): ImportIntakeState {
   return clearFeedbackState(state, { latestPreview, saveNotice });

--- a/src/lib/features/imports/page-actions.ts
+++ b/src/lib/features/imports/page-actions.ts
@@ -1,4 +1,9 @@
-import type { ImportBatch, ImportSourceType, OwnerProfile } from '$lib/core/domain/types';
+import type {
+  ImportBatch,
+  ImportPreviewResult,
+  ImportSourceType,
+  OwnerProfile,
+} from '$lib/core/domain/types';
 import {
   applyCommitErrorState,
   applyCommitSuccessState,
@@ -15,11 +20,16 @@ export interface ImportsPreviewDeps {
     sourceType: ImportSourceType;
     rawText: string;
     ownerProfile?: OwnerProfile | null;
-  }) => Promise<ImportBatch>;
+  }) => Promise<ImportPreviewResult>;
 }
 
 export interface ImportsCommitDeps {
-  commitImportBatch: (batchId: string) => Promise<ImportBatch>;
+  getOwnerProfile: () => OwnerProfile | null;
+  commitImportBatch: (input: {
+    sourceType: ImportSourceType;
+    rawText: string;
+    ownerProfile?: OwnerProfile | null;
+  }) => Promise<ImportBatch>;
 }
 
 function withUpdatedIntake(
@@ -100,7 +110,6 @@ export async function previewImportsPage(
     return withUpdatedIntake(
       {
         ...state,
-        batches: upsertBatch(state.batches, latestPreview),
       },
       applyPreviewSuccessState(state.intake, latestPreview)
     );
@@ -121,14 +130,18 @@ export async function commitImportsPage(
   }
 
   try {
-    const committed = await deps.commitImportBatch(state.intake.latestPreview.id);
+    const committed = await deps.commitImportBatch({
+      sourceType: state.intake.sourceType,
+      rawText: state.intake.payload,
+      ownerProfile: deps.getOwnerProfile(),
+    });
 
     return withUpdatedIntake(
       {
         ...state,
         batches: upsertBatch(state.batches, committed),
       },
-      applyCommitSuccessState(state.intake, committed)
+      applyCommitSuccessState(state.intake, null)
     );
   } catch (error) {
     return withUpdatedIntake(

--- a/src/lib/features/imports/parsers.ts
+++ b/src/lib/features/imports/parsers.ts
@@ -4,6 +4,18 @@ import type { HealthEvent, JournalEntry } from '$lib/core/domain/types';
 import { createRecordId } from '$lib/core/shared/ids';
 import { createRecordMeta } from '$lib/core/shared/records';
 
+function buildAppleHealthSourceRecordId(
+  attributes: Record<string, string>,
+  sourceTimestamp: string
+): string {
+  const sourceName = attributes.sourceName?.trim() || 'unknown';
+  const metricType = attributes.type?.trim() || 'unknown';
+  const endTimestamp = attributes.endDate?.trim() || sourceTimestamp;
+  const unit = attributes.unit?.trim() || '';
+  const value = attributes.value?.trim() || '';
+  return `${sourceName}:${metricType}:${sourceTimestamp}:${endTimestamp}:${unit}:${value}`;
+}
+
 export function parseAppleHealthXml(xml: string): HealthEvent[] {
   const recordMatches = [...xml.matchAll(/<Record\s+([^>]+?)\s*\/?>/g)];
   const importedAt = nowIso();
@@ -18,7 +30,7 @@ export function parseAppleHealthXml(xml: string): HealthEvent[] {
       ...createRecordMeta(createRecordId('apple-import'), importedAt),
       sourceType: 'import',
       sourceApp: 'Apple Health XML',
-      sourceRecordId: `${attributes.sourceName ?? 'unknown'}:${sourceTimestamp}`,
+      sourceRecordId: buildAppleHealthSourceRecordId(attributes, sourceTimestamp),
       sourceTimestamp,
       localDay: sourceTimestamp.slice(0, 10),
       timezone: 'UTC',

--- a/src/lib/features/imports/source-config.ts
+++ b/src/lib/features/imports/source-config.ts
@@ -1,4 +1,5 @@
 import type { ImportSourceType } from '$lib/core/domain/types';
+import { getExternalSourceDefinition } from '$lib/core/domain/external-sources';
 import type { DeviceSourceManifest } from '$lib/features/integrations/manifests/device-sources';
 import {
   buildHealthKitImportHelperCopy,
@@ -9,6 +10,11 @@ import {
 export interface ImportSourceConfig {
   label: string;
   description: string;
+  sourceMetadata?: {
+    sourceName: string;
+    authMode: string;
+    reliability: string;
+  };
   helper?: ImportSourceHelperCopy;
   sampleBundle?: {
     filename: string;
@@ -30,9 +36,17 @@ export function buildImportSourceCatalog(input: {
 }): ImportSourceCatalog {
   const config: Record<ImportSourceType, ImportSourceConfig> = {
     'healthkit-companion': {
-      label: 'iPhone bundle / Shortcuts JSON',
+      label: input.healthkitManifest.label,
       description:
         'Preferred no-Mac T9 path. Use Apple Shortcuts to export this JSON bundle, or paste the same contract from a native iPhone companion build.',
+      sourceMetadata: (() => {
+        const source = getExternalSourceDefinition('healthkit-companion');
+        return {
+          sourceName: source.sourceName,
+          authMode: source.authMode,
+          reliability: source.reliability,
+        };
+      })(),
       helper: buildHealthKitImportHelperCopy(input.healthkitManifest),
       sampleBundle: {
         filename: 'sample-healthkit-bundle.json',
@@ -44,6 +58,14 @@ export function buildImportSourceCatalog(input: {
       label: 'SMART sandbox FHIR JSON',
       description:
         'T10 proof lane. Paste a SMART sandbox FHIR Bundle after you configure your single-owner profile in Settings.',
+      sourceMetadata: (() => {
+        const source = getExternalSourceDefinition('smart-fhir-sandbox');
+        return {
+          sourceName: source.sourceName,
+          authMode: source.authMode,
+          reliability: source.reliability,
+        };
+      })(),
       helper: buildSmartFhirImportHelperCopy(),
       sampleBundle: {
         filename: 'sample-smart-fhir-bundle.json',

--- a/src/lib/features/imports/store.ts
+++ b/src/lib/features/imports/store.ts
@@ -149,7 +149,10 @@ export async function dedupeImportedEvents(
 
     seenSourceRecordIds.add(sourceRecordId);
 
-    const existing = await store.healthEvents.where('sourceRecordId').equals(sourceRecordId).first();
+    const existing = await store.healthEvents
+      .where('sourceRecordId')
+      .equals(sourceRecordId)
+      .first();
 
     if (existing) {
       duplicates.push(event);

--- a/src/lib/features/imports/store.ts
+++ b/src/lib/features/imports/store.ts
@@ -10,6 +10,7 @@ import type {
   HealthEvent,
   ImportArtifact,
   ImportBatch,
+  ImportPreviewResult,
   ImportSourceType,
   JournalEntry,
   OwnerProfile,
@@ -49,23 +50,17 @@ async function stageHealthEventBatch(
   >,
   events: HealthEvent[],
   analysis: ImportPayloadAnalysis | null
-): Promise<ImportBatch> {
+): Promise<ImportPreviewResult> {
   const { adds, duplicates } = await dedupeImportedEvents(store, events);
-  const batch = await createImportBatch(store, sourceType);
-  await stageArtifacts({
-    artifactTable: store.importArtifacts,
-    batchId: batch.id,
-    artifactType: 'healthEvent',
-    records: adds,
-  });
-
-  batch.summary = {
-    adds: adds.length,
-    duplicates: duplicates.length,
-    warnings: warningCount(analysis),
+  return {
+    sourceType,
+    status: 'preview',
+    summary: {
+      adds: adds.length,
+      duplicates: duplicates.length,
+      warnings: warningCount(analysis),
+    },
   };
-  await store.importBatches.put(batch);
-  return batch;
 }
 
 async function stageArtifacts<T extends HealthEvent | JournalEntry>(input: {
@@ -150,10 +145,30 @@ export async function dedupeImportedEvents(
   return { adds, duplicates };
 }
 
+export async function dedupeImportedJournalEntries(
+  store: ImportedRecordsStore,
+  entries: JournalEntry[]
+): Promise<{ adds: JournalEntry[]; duplicates: JournalEntry[] }> {
+  const adds: JournalEntry[] = [];
+  const duplicates: JournalEntry[] = [];
+
+  for (const entry of entries) {
+    const existing = await store.journalEntries.get(entry.id);
+
+    if (existing) {
+      duplicates.push(entry);
+    } else {
+      adds.push(entry);
+    }
+  }
+
+  return { adds, duplicates };
+}
+
 export async function previewImport(
   store: ImportsStorage,
   input: { sourceType: ImportSourceType; rawText: string; ownerProfile?: OwnerProfile | null }
-): Promise<ImportBatch> {
+): Promise<ImportPreviewResult> {
   const analysis = analyzeImportPayload(input.rawText);
   const resolvedSourceType = analysis?.sourceType ?? input.sourceType;
 
@@ -188,41 +203,101 @@ export async function previewImport(
   }
 
   const parsedEntries = analysis?.journalEntries ?? parseDayOneExport(input.rawText);
-  const batch = await createImportBatch(store, resolvedSourceType);
-  await stageArtifacts({
-    artifactTable: store.importArtifacts,
-    batchId: batch.id,
-    artifactType: 'journalEntry',
-    records: parsedEntries,
-  });
-
-  batch.summary = {
-    adds: parsedEntries.length,
-    duplicates: 0,
-    warnings: warningCount(analysis),
+  const { adds, duplicates } = await dedupeImportedJournalEntries(store, parsedEntries);
+  return {
+    sourceType: resolvedSourceType,
+    status: 'preview',
+    summary: {
+      adds: adds.length,
+      duplicates: duplicates.length,
+      warnings: warningCount(analysis),
+    },
   };
-  await store.importBatches.put(batch);
-  return batch;
 }
 
 export async function commitImportBatch(
   store: ImportsStorage,
-  batchId: string
+  input: { sourceType: ImportSourceType; rawText: string; ownerProfile?: OwnerProfile | null }
 ): Promise<ImportBatch> {
-  const batch = await store.importBatches.get(batchId);
-  if (!batch) throw new Error('Import batch not found');
-
-  const artifacts = await store.importArtifacts.where('batchId').equals(batchId).toArray();
+  const analysis = analyzeImportPayload(input.rawText);
+  const resolvedSourceType = analysis?.sourceType ?? input.sourceType;
+  const batch = await createImportBatch(store, resolvedSourceType);
   const affectedDays = new Set<string>();
+  let adds = 0;
+  let duplicates = 0;
 
-  for (const artifact of artifacts) {
-    if (artifact.artifactType === 'healthEvent' && artifact.payload) {
-      const event = structuredClone(artifact.payload) as unknown as HealthEvent;
+  if (resolvedSourceType === 'apple-health-xml') {
+    const parsed = analysis?.healthEvents ?? parseAppleHealthXml(input.rawText);
+    const deduped = await dedupeImportedEvents(store, parsed);
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
+    await stageArtifacts({
+      artifactTable: store.importArtifacts,
+      batchId: batch.id,
+      artifactType: 'healthEvent',
+      records: deduped.adds,
+    });
+    for (const event of deduped.adds) {
       await store.healthEvents.put(event);
       affectedDays.add(event.localDay);
     }
-    if (artifact.artifactType === 'journalEntry' && artifact.payload) {
-      await store.journalEntries.put(structuredClone(artifact.payload) as unknown as JournalEntry);
+  } else if (resolvedSourceType === 'healthkit-companion') {
+    const parsed = analysis?.healthEvents ?? importHealthKitCompanionBundle(input.rawText).events;
+    const deduped = await dedupeImportedEvents(store, parsed);
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
+    await stageArtifacts({
+      artifactTable: store.importArtifacts,
+      batchId: batch.id,
+      artifactType: 'healthEvent',
+      records: deduped.adds,
+    });
+    for (const event of deduped.adds) {
+      await store.healthEvents.put(event);
+      affectedDays.add(event.localDay);
+    }
+  } else if (resolvedSourceType === 'smart-fhir-sandbox') {
+    if (!input.ownerProfile) {
+      throw new Error(
+        'Configure your owner profile in Settings before previewing SMART clinical imports.'
+      );
+    }
+    const normalized = analysis ?? analyzeImportPayload(input.rawText);
+    const imported = resolveSmartClinicalImport(normalized, input.rawText);
+    const match = resolveClinicalPatientMatch(imported.patientIdentity, [
+      ownerCandidate(input.ownerProfile),
+    ]);
+
+    if (match.status !== 'exact') {
+      throw new Error(match.reason);
+    }
+
+    const deduped = await dedupeImportedEvents(store, imported.events);
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
+    await stageArtifacts({
+      artifactTable: store.importArtifacts,
+      batchId: batch.id,
+      artifactType: 'healthEvent',
+      records: deduped.adds,
+    });
+    for (const event of deduped.adds) {
+      await store.healthEvents.put(event);
+      affectedDays.add(event.localDay);
+    }
+  } else {
+    const parsedEntries = analysis?.journalEntries ?? parseDayOneExport(input.rawText);
+    const deduped = await dedupeImportedJournalEntries(store, parsedEntries);
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
+    await stageArtifacts({
+      artifactTable: store.importArtifacts,
+      batchId: batch.id,
+      artifactType: 'journalEntry',
+      records: deduped.adds,
+    });
+    for (const entry of deduped.adds) {
+      await store.journalEntries.put(entry);
     }
   }
 
@@ -230,6 +305,11 @@ export async function commitImportBatch(
     ...batch,
     ...updateRecordMeta(batch, batch.id, nowIso()),
     status: 'committed',
+    summary: {
+      adds,
+      duplicates,
+      warnings: warningCount(analysis),
+    },
   };
 
   await store.importBatches.put(committed);

--- a/src/lib/features/imports/store.ts
+++ b/src/lib/features/imports/store.ts
@@ -122,18 +122,34 @@ export async function createImportBatch(
   return batch;
 }
 
+function normalizeSourceRecordId(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
 export async function dedupeImportedEvents(
   store: ImportedRecordsStore,
   events: HealthEvent[]
 ): Promise<{ adds: HealthEvent[]; duplicates: HealthEvent[] }> {
   const adds: HealthEvent[] = [];
   const duplicates: HealthEvent[] = [];
+  const seenSourceRecordIds = new Set<string>();
 
   for (const event of events) {
-    const existing = await store.healthEvents
-      .where('sourceRecordId')
-      .equals(event.sourceRecordId ?? '')
-      .first();
+    const sourceRecordId = normalizeSourceRecordId(event.sourceRecordId);
+    if (!sourceRecordId) {
+      adds.push(event);
+      continue;
+    }
+
+    if (seenSourceRecordIds.has(sourceRecordId)) {
+      duplicates.push(event);
+      continue;
+    }
+
+    seenSourceRecordIds.add(sourceRecordId);
+
+    const existing = await store.healthEvents.where('sourceRecordId').equals(sourceRecordId).first();
 
     if (existing) {
       duplicates.push(event);

--- a/src/lib/features/nutrition/Page.svelte
+++ b/src/lib/features/nutrition/Page.svelte
@@ -173,9 +173,18 @@
     page = loadPlannedMealIntoDraft(page);
   }
 
-  async function planRecommendation(recommendationId: string, kind: 'food' | 'recipe') {
+  async function planRecommendation(
+    recommendationId: string,
+    kind: 'food' | 'recipe',
+    canPlanDirectly: boolean
+  ) {
     await runNutritionAction(async () => {
-      const draft = getNutritionRecommendationPlanDraft(page, recommendationId, kind);
+      const draft = getNutritionRecommendationPlanDraft(
+        page,
+        recommendationId,
+        kind,
+        canPlanDirectly
+      );
       if (!draft) {
         return;
       }
@@ -208,10 +217,12 @@
     <NutritionComposerSection
       searchQuery={page.searchQuery}
       searchNotice={page.searchNotice}
+      searchMetadata={page.searchMetadata}
       matches={page.matches}
       packagedQuery={page.packagedQuery}
       barcodeQuery={page.barcodeQuery}
       packagedNotice={page.packagedNotice}
+      packagedMetadata={page.packagedMetadata}
       packagedMatches={page.packagedMatches}
       recipeQuery={page.recipeQuery}
       recipeNotice={page.recipeNotice}

--- a/src/lib/features/nutrition/client.ts
+++ b/src/lib/features/nutrition/client.ts
@@ -219,8 +219,7 @@ export async function lookupPackagedBarcode(
       cacheStatus: 'local-cache',
       degradationStatus: 'none',
     } satisfies ExternalSourceMetadata,
-  })
-  );
+  }));
 
   return applyNutritionBarcodeMatch(
     state,

--- a/src/lib/features/nutrition/client.ts
+++ b/src/lib/features/nutrition/client.ts
@@ -33,10 +33,20 @@ import type {
   NutritionPlannedMealDraft,
   NutritionRecurringMealDraft,
 } from './actions';
-import { findFoodCatalogItemByBarcode, searchFoodData, searchPackagedFoodCatalog } from './lookup';
+import {
+  findOpenFoodFactsCatalogItemByBarcode,
+  searchPackagedFoodCatalog,
+  searchUsdaFoodCatalog,
+} from './lookup';
 import type { FoodLookupResult } from './types';
 import { listFoodCatalogItems, listRecipeCatalogItems } from './store';
 import type { RecipeCatalogItem } from '$lib/core/domain/types';
+import type { ExternalSourceMetadata } from '$lib/core/domain/external-sources';
+import type {
+  BarcodeLookupResponse,
+  SearchPackagedResponse,
+  SearchUsdaResponse,
+} from '$lib/server/nutrition/search-service';
 
 export {
   createNutritionPageState,
@@ -130,31 +140,49 @@ export async function clearNutritionPlannedMeal(
 }
 
 export async function searchPackagedFoods(state: NutritionPageState): Promise<NutritionPageState> {
-  const packagedMatches = await packagedSearchClient.request(
+  const response = await packagedSearchClient.request<SearchPackagedResponse>(
     {
       query: state.packagedQuery,
     },
-    async (db) => searchPackagedFoodCatalog(state.packagedQuery, await listFoodCatalogItems(db))
+    async (db) => ({
+      matches: searchPackagedFoodCatalog(state.packagedQuery, await listFoodCatalogItems(db)),
+      metadata: {
+        provenance: [],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'none',
+      } satisfies ExternalSourceMetadata,
+    })
   );
 
   return applyPackagedNutritionMatches(
     state,
-    packagedMatches,
-    packagedMatches.length ? '' : 'No packaged food matches found.'
+    response.matches,
+    response.notice ?? (response.matches.length ? '' : 'No packaged food matches found.'),
+    response.metadata
   );
 }
 
 export async function searchNutritionFoods(state: NutritionPageState): Promise<NutritionPageState> {
-  const response = await usdaSearchClient.request<{ matches: FoodLookupResult[]; notice?: string }>(
+  const response = await usdaSearchClient.request<SearchUsdaResponse>(
     {
       query: state.searchQuery,
     },
     async (db) => ({
-      matches: searchFoodData(state.searchQuery, await listFoodCatalogItems(db)),
+      matches: searchUsdaFoodCatalog(state.searchQuery, await listFoodCatalogItems(db)),
+      metadata: {
+        provenance: [],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'none',
+      } satisfies ExternalSourceMetadata,
     })
   );
 
-  return applyNutritionSearchMatches(state, response.matches, response.notice ?? '');
+  return applyNutritionSearchMatches(
+    state,
+    response.matches,
+    response.notice ?? '',
+    response.metadata
+  );
 }
 
 export async function useNutritionMatch(
@@ -178,13 +206,28 @@ export async function useNutritionMatch(
 export async function lookupPackagedBarcode(
   state: NutritionPageState
 ): Promise<NutritionPageState> {
-  const match = await createNutritionLookupClient(
+  const response = await createNutritionLookupClient(
     `/api/nutrition/barcode/${encodeURIComponent(state.barcodeQuery)}`
-  ).request<FoodLookupResult | null>({}, async (db) =>
-    findFoodCatalogItemByBarcode(state.barcodeQuery, await listFoodCatalogItems(db))
+  ).request<BarcodeLookupResponse>({}, async (db) => ({
+    match: findOpenFoodFactsCatalogItemByBarcode(
+      state.barcodeQuery,
+      await listFoodCatalogItems(db)
+    ),
+    notice: 'Packaged food loaded from local cache.',
+    metadata: {
+      provenance: [],
+      cacheStatus: 'local-cache',
+      degradationStatus: 'none',
+    } satisfies ExternalSourceMetadata,
+  })
   );
 
-  return applyNutritionBarcodeMatch(state, match);
+  return applyNutritionBarcodeMatch(
+    state,
+    response.match,
+    response.match ? undefined : response.notice,
+    response.metadata
+  );
 }
 
 export async function searchNutritionRecipes(

--- a/src/lib/features/nutrition/components/NutritionComposerSection.svelte
+++ b/src/lib/features/nutrition/components/NutritionComposerSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { ExternalSourceMetadata } from '$lib/core/domain/external-sources';
   import type { RecipeCatalogItem } from '$lib/core/domain/types';
   import { Button, Field, SectionCard } from '$lib/core/ui/primitives';
   import {
@@ -12,10 +13,12 @@
   let {
     searchQuery,
     searchNotice,
+    searchMetadata,
     matches,
     packagedQuery,
     barcodeQuery,
     packagedNotice,
+    packagedMetadata,
     packagedMatches,
     recipeQuery,
     recipeNotice,
@@ -40,10 +43,12 @@
   }: {
     searchQuery: string;
     searchNotice: string;
+    searchMetadata: ExternalSourceMetadata | null;
     matches: FoodLookupResult[];
     packagedQuery: string;
     barcodeQuery: string;
     packagedNotice: string;
+    packagedMetadata: ExternalSourceMetadata | null;
     packagedMatches: FoodLookupResult[];
     recipeQuery: string;
     recipeNotice: string;
@@ -66,6 +71,20 @@
     onSaveCustomFood: () => void;
     onSaveRecurringMeal: () => void;
   } = $props();
+
+  function createMetadataRows(metadata: ExternalSourceMetadata | null): string[] {
+    if (!metadata) {
+      return [];
+    }
+
+    const sourceNames = metadata.provenance.map((item) => item.sourceName).join(', ');
+
+    return [
+      sourceNames ? `Sources: ${sourceNames}` : '',
+      `Cache: ${metadata.cacheStatus}`,
+      `Status: ${metadata.degradationStatus}`,
+    ].filter(Boolean);
+  }
 </script>
 
 <SectionCard title="Meal logging">
@@ -83,6 +102,13 @@
 
   {#if searchNotice}
     <p class="status-copy">{searchNotice}</p>
+  {/if}
+  {#if searchMetadata}
+    <div class="metadata-block">
+      {#each createMetadataRows(searchMetadata) as row (row)}
+        <p class="status-copy">{row}</p>
+      {/each}
+    </div>
   {/if}
 
   {#if matches.length}
@@ -132,6 +158,13 @@
 
     {#if packagedNotice}
       <p class="status-copy">{packagedNotice}</p>
+    {/if}
+    {#if packagedMetadata}
+      <div class="metadata-block">
+        {#each createMetadataRows(packagedMetadata) as row (row)}
+          <p class="status-copy">{row}</p>
+        {/each}
+      </div>
     {/if}
 
     {#if packagedMatches.length}
@@ -276,6 +309,10 @@
 <style>
   .field-grid {
     margin: 1rem 0;
+  }
+
+  .metadata-block {
+    margin-top: 0.35rem;
   }
 
   .match-list {

--- a/src/lib/features/nutrition/components/NutritionRecommendationsSection.svelte
+++ b/src/lib/features/nutrition/components/NutritionRecommendationsSection.svelte
@@ -12,7 +12,11 @@
     recommendationContextRows: string[];
     recommendations: NutritionRecommendation[];
     onUseRecommendation: (id: string, kind: 'food' | 'recipe') => void;
-    onPlanRecommendation: (id: string, kind: 'food' | 'recipe') => void;
+    onPlanRecommendation: (
+      id: string,
+      kind: 'food' | 'recipe',
+      canPlanDirectly: boolean
+    ) => void;
   } = $props();
 </script>
 
@@ -29,6 +33,9 @@
         <li>
           <div>
             <strong>{recommendation.title}</strong>
+            <p>{recommendation.subtitle}</p>
+            <p>Source: {recommendation.sourceName}</p>
+            <p>Posture: {recommendation.sourcePosture}</p>
             <p class="recommendation-meta">
               <span class="recommendation-score score-chip">{recommendation.score}</span>
               <span>{createRecommendationSummary(recommendation)}</span>
@@ -46,9 +53,15 @@
             </Button>
             <Button
               variant="secondary"
-              onclick={() => onPlanRecommendation(recommendation.id, recommendation.kind)}
+              onclick={() =>
+                onPlanRecommendation(
+                  recommendation.id,
+                  recommendation.kind,
+                  recommendation.canPlanDirectly
+                )}
+              disabled={!recommendation.canPlanDirectly}
             >
-              Plan next
+              {recommendation.canPlanDirectly ? 'Plan next' : 'Review first'}
             </Button>
           </div>
         </li>

--- a/src/lib/features/nutrition/components/NutritionRecommendationsSection.svelte
+++ b/src/lib/features/nutrition/components/NutritionRecommendationsSection.svelte
@@ -12,11 +12,7 @@
     recommendationContextRows: string[];
     recommendations: NutritionRecommendation[];
     onUseRecommendation: (id: string, kind: 'food' | 'recipe') => void;
-    onPlanRecommendation: (
-      id: string,
-      kind: 'food' | 'recipe',
-      canPlanDirectly: boolean
-    ) => void;
+    onPlanRecommendation: (id: string, kind: 'food' | 'recipe', canPlanDirectly: boolean) => void;
   } = $props();
 </script>
 

--- a/src/lib/features/nutrition/lookup.ts
+++ b/src/lib/features/nutrition/lookup.ts
@@ -11,6 +11,7 @@ export const USDA_FALLBACK_FOODS: FoodLookupResult[] = [
     carbs: 52,
     fat: 7,
     sourceName: 'USDA fallback',
+    sourceType: 'usda-fallback',
   },
   {
     id: 'fdc-chicken-salad',
@@ -21,6 +22,7 @@ export const USDA_FALLBACK_FOODS: FoodLookupResult[] = [
     carbs: 18,
     fat: 19,
     sourceName: 'USDA fallback',
+    sourceType: 'usda-fallback',
   },
   {
     id: 'fdc-lentil-soup',
@@ -31,8 +33,19 @@ export const USDA_FALLBACK_FOODS: FoodLookupResult[] = [
     carbs: 39,
     fat: 6,
     sourceName: 'USDA fallback',
+    sourceType: 'usda-fallback',
   },
 ];
+
+export function filterUsdaCatalogItems(catalogItems: FoodCatalogItem[] = []): FoodCatalogItem[] {
+  return catalogItems.filter((item) => item.sourceType === 'usda-fallback');
+}
+
+export function filterOpenFoodFactsCatalogItems(
+  catalogItems: FoodCatalogItem[] = []
+): FoodCatalogItem[] {
+  return catalogItems.filter((item) => item.sourceType === 'open-food-facts');
+}
 
 export function foodLookupResultFromCatalogItem(item: FoodCatalogItem): FoodLookupResult {
   return {
@@ -98,6 +111,13 @@ export function searchPackagedFoodCatalog(
     .map((item) => foodLookupResultFromCatalogItem(item));
 }
 
+export function searchUsdaFoodCatalog(
+  query: string,
+  catalogItems: FoodCatalogItem[] = []
+): FoodLookupResult[] {
+  return searchFoodData(query, filterUsdaCatalogItems(catalogItems));
+}
+
 export function findFoodCatalogItemByBarcode(
   barcode: string,
   catalogItems: FoodCatalogItem[] = []
@@ -107,6 +127,13 @@ export function findFoodCatalogItemByBarcode(
 
   const item = catalogItems.find((candidate) => candidate.barcode === normalized);
   return item ? foodLookupResultFromCatalogItem(item) : null;
+}
+
+export function findOpenFoodFactsCatalogItemByBarcode(
+  barcode: string,
+  catalogItems: FoodCatalogItem[] = []
+): FoodLookupResult | null {
+  return findFoodCatalogItemByBarcode(barcode, filterOpenFoodFactsCatalogItems(catalogItems));
 }
 
 export function attachNutrientsToFoodEntry(

--- a/src/lib/features/nutrition/page-actions.ts
+++ b/src/lib/features/nutrition/page-actions.ts
@@ -76,8 +76,13 @@ export function updateNutritionFormField(
 export function getNutritionRecommendationPlanDraft(
   state: NutritionPageState,
   recommendationId: string,
-  kind: 'food' | 'recipe'
+  kind: 'food' | 'recipe',
+  canPlanDirectly = true
 ): NutritionActionDraft | null {
+  if (!canPlanDirectly) {
+    return null;
+  }
+
   if (kind === 'food') {
     const item = state.catalogItems.find((candidate) => candidate.id === recommendationId);
     if (!item) {

--- a/src/lib/features/nutrition/recommend.ts
+++ b/src/lib/features/nutrition/recommend.ts
@@ -1,4 +1,8 @@
 import type { FoodCatalogItem, RecipeCatalogItem } from '$lib/core/domain/types';
+import {
+  getExternalSourceDefinition,
+  type ExternalSourceProductionPosture,
+} from '$lib/core/domain/external-sources';
 
 export interface NutritionRecommendationContext {
   mealType: string;
@@ -13,6 +17,9 @@ export interface NutritionRecommendation {
   kind: 'food' | 'recipe';
   title: string;
   subtitle: string;
+  sourceName: string;
+  sourcePosture: ExternalSourceProductionPosture;
+  canPlanDirectly: boolean;
   score: number;
   reasons: string[];
 }
@@ -168,6 +175,14 @@ function scoreFood(
     kind: 'food',
     title: item.name,
     subtitle: createFoodRecommendationSubtitle(item),
+    sourceName: item.sourceName,
+    sourcePosture:
+      item.sourceType === 'open-food-facts'
+        ? getExternalSourceDefinition('open-food-facts').productionPosture
+        : item.sourceType === 'usda-fallback'
+          ? getExternalSourceDefinition('usda-fooddata-central').productionPosture
+          : 'adopt',
+    canPlanDirectly: true,
     score: Math.round(score),
     reasons,
   };
@@ -214,6 +229,9 @@ function scoreRecipe(
     kind: 'recipe',
     title: item.title,
     subtitle: [item.mealType, item.cuisine].filter(Boolean).join(' · ') || item.sourceName,
+    sourceName: item.sourceName,
+    sourcePosture: getExternalSourceDefinition('themealdb').productionPosture,
+    canPlanDirectly: getExternalSourceDefinition('themealdb').productionPosture === 'adopt',
     score: Math.round(score),
     reasons,
   };

--- a/src/lib/features/nutrition/state.ts
+++ b/src/lib/features/nutrition/state.ts
@@ -17,6 +17,7 @@ import {
 } from './planned-meal-resolution';
 import { attachNutrientsToFoodEntry, searchFoodData } from './lookup';
 import type { FoodLookupResult } from './types';
+import type { ExternalSourceMetadata } from '$lib/core/domain/external-sources';
 import {
   buildNutritionRecommendationContext,
   buildDailyNutritionSummary,
@@ -62,6 +63,8 @@ export interface NutritionPageState {
   searchNotice: string;
   packagedNotice: string;
   recipeNotice: string;
+  searchMetadata: ExternalSourceMetadata | null;
+  packagedMetadata: ExternalSourceMetadata | null;
   summary: NutritionSummary;
   favoriteMeals: FavoriteMeal[];
   catalogItems: FoodCatalogItem[];
@@ -116,6 +119,8 @@ export function createNutritionPageState(): NutritionPageState {
     searchNotice: '',
     packagedNotice: '',
     recipeNotice: '',
+    searchMetadata: null,
+    packagedMetadata: null,
     summary: createEmptyNutritionSummary(),
     favoriteMeals: [],
     catalogItems: [],
@@ -244,24 +249,28 @@ export function runNutritionSearch(state: NutritionPageState): NutritionPageStat
 export function applyNutritionSearchMatches(
   state: NutritionPageState,
   matches: FoodLookupResult[],
-  searchNotice = ''
+  searchNotice = '',
+  searchMetadata: ExternalSourceMetadata | null = null
 ): NutritionPageState {
   return {
     ...state,
     matches,
     searchNotice,
+    searchMetadata,
   };
 }
 
 export function applyPackagedNutritionMatches(
   state: NutritionPageState,
   packagedMatches: FoodLookupResult[],
-  packagedNotice = ''
+  packagedNotice = '',
+  packagedMetadata: ExternalSourceMetadata | null = null
 ): NutritionPageState {
   return {
     ...state,
     packagedMatches,
     packagedNotice,
+    packagedMetadata,
   };
 }
 
@@ -279,13 +288,16 @@ export function applyNutritionRecipeMatches(
 
 export function applyNutritionBarcodeMatch(
   state: NutritionPageState,
-  match: FoodLookupResult | null
+  match: FoodLookupResult | null,
+  packagedNotice?: string,
+  packagedMetadata: ExternalSourceMetadata | null = null
 ): NutritionPageState {
   if (!match) {
     return {
       ...state,
       packagedMatches: [],
-      packagedNotice: 'No packaged food found for that barcode.',
+      packagedNotice: packagedNotice ?? 'No packaged food found for that barcode.',
+      packagedMetadata,
     };
   }
 
@@ -297,7 +309,8 @@ export function applyNutritionBarcodeMatch(
       },
       match
     ),
-    packagedNotice: 'Packaged food loaded from barcode.',
+    packagedNotice: packagedNotice ?? 'Packaged food loaded from barcode.',
+    packagedMetadata,
   };
 }
 

--- a/src/lib/features/review/analytics-health.ts
+++ b/src/lib/features/review/analytics-health.ts
@@ -7,6 +7,7 @@ import type {
 } from '$lib/core/domain/types';
 import { buildHealthEventDisplay } from '$lib/core/shared/health-events';
 import { MIN_SLEEP_HOURS } from './analytics-shared';
+import type { ReviewReferenceLink } from './analytics-shared';
 
 export function buildAssessmentSummary(assessments: AssessmentResult[]): string[] {
   return assessments
@@ -63,6 +64,66 @@ export function buildHealthHighlights(records: DailyRecord[], events: HealthEven
   }
 
   return highlights;
+}
+
+export function buildHealthReferenceLinks(events: HealthEvent[]): ReviewReferenceLink[] {
+  const seen = new Set<string>();
+  const links: ReviewReferenceLink[] = [];
+
+  for (const event of events) {
+    if (event.eventType !== 'medication-dose') {
+      continue;
+    }
+
+    const payload = event.payload as { templateName?: unknown; referenceUrl?: unknown } | undefined;
+    const label =
+      typeof payload?.templateName === 'string' && payload.templateName.trim().length > 0
+        ? payload.templateName.trim()
+        : null;
+    const href =
+      typeof payload?.referenceUrl === 'string' && payload.referenceUrl.trim().length > 0
+        ? payload.referenceUrl.trim()
+        : null;
+
+    if (!label || !href || seen.has(href)) {
+      continue;
+    }
+
+    seen.add(href);
+    links.push({ label, href });
+  }
+
+  return links;
+}
+
+export function buildSymptomReferenceLinks(events: HealthEvent[]): ReviewReferenceLink[] {
+  const seen = new Set<string>();
+  const links: ReviewReferenceLink[] = [];
+
+  for (const event of events) {
+    if (event.eventType !== 'symptom') {
+      continue;
+    }
+
+    const payload = event.payload as { symptom?: unknown; referenceUrl?: unknown } | undefined;
+    const label =
+      typeof payload?.symptom === 'string' && payload.symptom.trim().length > 0
+        ? payload.symptom.trim()
+        : null;
+    const href =
+      typeof payload?.referenceUrl === 'string' && payload.referenceUrl.trim().length > 0
+        ? payload.referenceUrl.trim()
+        : null;
+
+    if (!label || !href || seen.has(href)) {
+      continue;
+    }
+
+    seen.add(href);
+    links.push({ label, href });
+  }
+
+  return links;
 }
 
 function formatJournalEntryLabel(entry: JournalEntry): string {

--- a/src/lib/features/review/analytics-shared.ts
+++ b/src/lib/features/review/analytics-shared.ts
@@ -78,6 +78,11 @@ export interface ReviewSavedExperimentVerdict {
   provenance: string[];
 }
 
+export interface ReviewReferenceLink {
+  label: string;
+  href: string;
+}
+
 export interface WeeklyReviewData {
   anchorDay: string;
   snapshot: ReviewSnapshot;
@@ -94,6 +99,8 @@ export interface WeeklyReviewData {
   grocerySignals: string[];
   deviceHighlights: string[];
   assessmentSummary: string[];
+  healthReferenceLinks?: ReviewReferenceLink[];
+  symptomReferenceLinks?: ReviewReferenceLink[];
   healthHighlights: string[];
   contextSignals: string[];
   contextCaptureLinkedEventIds: string[];

--- a/src/lib/features/review/analytics.ts
+++ b/src/lib/features/review/analytics.ts
@@ -6,6 +6,7 @@ export {
   type ReviewDecision,
   type ReviewDecisionCard,
   type ReviewNutritionStrategyItem,
+  type ReviewReferenceLink,
   type ReviewRecommendationTarget,
   type ReviewWeeklyRecommendation,
   type WeeklyReviewData,
@@ -39,6 +40,8 @@ export {
   buildContextSignals,
   buildDeviceHighlights,
   buildHealthHighlights,
+  buildHealthReferenceLinks,
   buildJournalHighlights,
   buildPatternHighlights,
+  buildSymptomReferenceLinks,
 } from './analytics-health';

--- a/src/lib/features/review/components/ReviewListSection.svelte
+++ b/src/lib/features/review/components/ReviewListSection.svelte
@@ -10,9 +10,7 @@
     section: ReviewSection;
   } = $props();
 
-  function isLinkItem(
-    item: ReviewSection['items'][number]
-  ): item is ReviewReferenceItem {
+  function isLinkItem(item: ReviewSection['items'][number]): item is ReviewReferenceItem {
     return (
       typeof item === 'object' &&
       item !== null &&

--- a/src/lib/features/review/components/ReviewListSection.svelte
+++ b/src/lib/features/review/components/ReviewListSection.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { toSafeExternalHref } from '$lib/core/shared/external-links';
   import { EmptyState, SectionCard } from '$lib/core/ui/primitives';
-  import type { ReviewSection } from '$lib/features/review/model';
+  import type { ReviewReferenceItem, ReviewSection } from '$lib/features/review/model';
 
   let {
     section,
   }: {
     section: ReviewSection;
   } = $props();
+
+  function isLinkItem(
+    item: ReviewSection['items'][number]
+  ): item is ReviewReferenceItem {
+    return (
+      typeof item === 'object' &&
+      item !== null &&
+      'label' in item &&
+      'href' in item &&
+      'categoryLabel' in item &&
+      'kind' in item
+    );
+  }
+
+  function isSafeLinkItem(item: ReviewSection['items'][number]): item is ReviewReferenceItem {
+    return isLinkItem(item) && Boolean(toSafeExternalHref(item.href));
+  }
 </script>
 
 <SectionCard
@@ -16,8 +34,35 @@
 >
   {#if section.items.length}
     <ul class:review-strategy-list={section.emphasis === 'strategy'} class="summary-list">
-      {#each section.items as line (line)}
-        <li>{line}</li>
+      {#each section.items as item, index (`${typeof item === 'string' ? item : item.href}:${index}`)}
+        <li>
+          {#if isSafeLinkItem(item)}
+            <div class="reference-link-row">
+              {#if item.categoryLabel}
+                <span
+                  class:reference-pill--medication={item.kind === 'medication'}
+                  class:reference-pill--symptom={item.kind === 'symptom'}
+                  class="reference-pill"
+                >
+                  {item.categoryLabel}
+                </span>
+              {/if}
+              <a
+                href={toSafeExternalHref(item.href) ?? undefined}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`${item.categoryLabel} reference ${item.label} opens in new tab`}
+              >
+                {item.label}
+              </a>
+              <span class="external-link-hint" aria-hidden="true">Opens externally</span>
+            </div>
+          {:else if isLinkItem(item)}
+            {item.label}
+          {:else}
+            {item}
+          {/if}
+        </li>
       {/each}
     </ul>
   {:else if section.emptyTitle}
@@ -55,6 +100,42 @@
 
   .section-link {
     width: fit-content;
+  }
+
+  .reference-link-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.65rem;
+  }
+
+  .reference-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    border: 0.5px solid rgba(233, 195, 73, 0.2);
+    background: rgba(233, 195, 73, 0.1);
+    color: var(--phc-label);
+    font-size: 0.78rem;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
+  }
+
+  .reference-pill--medication {
+    border-color: rgba(73, 147, 233, 0.28);
+    background: rgba(73, 147, 233, 0.14);
+  }
+
+  .reference-pill--symptom {
+    border-color: rgba(233, 116, 73, 0.28);
+    background: rgba(233, 116, 73, 0.14);
+  }
+
+  .external-link-hint {
+    color: var(--phc-muted);
+    font-size: 0.8rem;
+    white-space: nowrap;
   }
 
   @media (max-width: 639px) {

--- a/src/lib/features/review/model.ts
+++ b/src/lib/features/review/model.ts
@@ -17,6 +17,7 @@ export {
   createReviewAdherenceCards,
   createReviewSections,
   createReviewTrendRows,
+  type ReviewReferenceItem,
   type ReviewAdherenceAuditItem,
   type ReviewAdherenceCard,
   type ReviewNutritionStrategyCard,

--- a/src/lib/features/review/snapshot-builder.ts
+++ b/src/lib/features/review/snapshot-builder.ts
@@ -23,9 +23,11 @@ import {
   buildDeviceHighlights,
   buildGrocerySignals,
   buildHealthHighlights,
+  buildHealthReferenceLinks,
   buildHeadline,
   buildJournalHighlights,
   buildPatternHighlights,
+  buildSymptomReferenceLinks,
   buildNutritionHighlights,
   buildNutritionStrategy,
   buildPlanningHighlights,
@@ -217,6 +219,8 @@ export function buildWeeklySnapshotFromWeekData(input: {
   const planningHighlights = buildPlanningHighlights(weeklyPlan, weekPlanSlots, weekGroceries);
   const deviceHighlights = buildDeviceHighlights(weekHealthEvents);
   const assessmentSummary = buildAssessmentSummary(weekAssessments);
+  const healthReferenceLinks = buildHealthReferenceLinks(weekHealthEvents);
+  const symptomReferenceLinks = buildSymptomReferenceLinks(weekHealthEvents);
   const healthHighlights = buildHealthHighlights(weekRecords, weekHealthEvents);
   const contextSignals = buildContextSignals(weekRecords, weekHealthEvents, weekJournalEntries);
   const patternHighlights = buildPatternHighlights(weekJournalEntries, weekHealthEvents);
@@ -295,6 +299,8 @@ export function buildWeeklySnapshotFromWeekData(input: {
     grocerySignals,
     deviceHighlights,
     assessmentSummary,
+    healthReferenceLinks,
+    symptomReferenceLinks,
     healthHighlights,
     contextSignals,
     contextCaptureLinkedEventIds: weekHealthEvents

--- a/src/lib/features/review/summary-sections.ts
+++ b/src/lib/features/review/summary-sections.ts
@@ -11,12 +11,19 @@ import {
 export type ReviewSection = {
   kind?: 'default' | 'decision-engine';
   title: string;
-  items: string[];
+  items: Array<string | ReviewReferenceItem>;
   emptyTitle?: string;
   emptyMessage?: string;
   emphasis?: 'default' | 'strategy';
   actionHref?: JournalIntentHref;
   actionLabel?: string;
+};
+
+export type ReviewReferenceItem = {
+  kind: 'medication' | 'symptom';
+  categoryLabel: 'Medication' | 'Symptom';
+  label: string;
+  href: string;
 };
 
 export type ReviewNutritionStrategyCard = {
@@ -40,6 +47,19 @@ export type ReviewAdherenceAuditItem = {
   detail: string;
   tone: 'steady' | 'mixed' | 'attention';
 };
+
+function createReferenceItems(
+  kind: ReviewReferenceItem['kind'],
+  categoryLabel: ReviewReferenceItem['categoryLabel'],
+  items: Array<{ label: string; href: string }>
+): ReviewReferenceItem[] {
+  return items.map((item) => ({
+    kind,
+    categoryLabel,
+    label: item.label,
+    href: item.href,
+  }));
+}
 
 function normalizeStrategyDetail(detail: string): string {
   const trimmed = detail.trim();
@@ -181,6 +201,16 @@ export function createReviewSections(weekly: WeeklyReviewData | null): ReviewSec
           title: 'Health highlights',
           items: weekly.healthHighlights,
           emptyMessage: 'Keep logging health context to unlock more useful weekly patterns.',
+        },
+        {
+          kind: 'default',
+          title: 'Health references',
+          items: [
+            ...createReferenceItems('medication', 'Medication', weekly.healthReferenceLinks ?? []),
+            ...createReferenceItems('symptom', 'Symptom', weekly.symptomReferenceLinks ?? []),
+          ],
+          emptyMessage:
+            'Log medications or suggested symptoms with reference links to surface trusted reading here during Review.',
         },
         {
           kind: 'default',

--- a/src/lib/features/timeline/Page.svelte
+++ b/src/lib/features/timeline/Page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { toSafeExternalHref } from '$lib/core/shared/external-links';
   import { Card, EmptyState, Field } from '$lib/core/ui/primitives';
   import {
     createTimelinePageState,
@@ -64,6 +65,19 @@
               </div>
               <p>{item.event.sourceApp}</p>
               <p>{item.sourceLabel} · {item.event.localDay}</p>
+              {#if toSafeExternalHref(item.referenceUrl)}
+                <p>
+                  <a
+                    class="timeline-reference-link"
+                    href={toSafeExternalHref(item.referenceUrl) ?? undefined}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={`Learn more about timeline event ${item.label}`}
+                  >
+                    Learn more
+                  </a>
+                </p>
+              {/if}
             </li>
           {/each}
         </ul>
@@ -110,6 +124,10 @@
   .timeline-list p {
     margin: 0.3rem 0 0;
     color: var(--phc-muted);
+  }
+
+  .timeline-reference-link {
+    color: var(--phc-label);
   }
 
   @media (max-width: 639px) {

--- a/src/lib/features/timeline/Page.svelte
+++ b/src/lib/features/timeline/Page.svelte
@@ -15,9 +15,23 @@
   import type { TimelineSourceFilter } from '$lib/features/timeline/service';
 
   let page = $state(createTimelinePageState());
+  let loadError = $state('');
+
+  function timelineErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : 'Timeline unavailable right now.';
+  }
 
   async function refreshTimeline() {
-    page = await loadTimelinePage(page);
+    try {
+      page = await loadTimelinePage(page);
+      loadError = '';
+    } catch (error) {
+      page = {
+        ...page,
+        loading: false,
+      };
+      loadError = timelineErrorMessage(error);
+    }
   }
 
   onBrowserRouteMount(refreshTimeline);
@@ -54,6 +68,10 @@
           </select>
         </Field>
       </div>
+
+      {#if loadError}
+        <p class="status-copy" role="alert">{loadError}</p>
+      {/if}
 
       {#if page.items.length}
         <ul class="timeline-list">

--- a/src/lib/features/timeline/service.ts
+++ b/src/lib/features/timeline/service.ts
@@ -1,5 +1,6 @@
 import type { HealthDbHealthEventsStore } from '$lib/core/db/types';
 import type { HealthEvent, SourceType } from '$lib/core/domain/types';
+import { normalizeSafeExternalUrl } from '$lib/core/shared/external-links';
 import {
   buildHealthEventDisplay,
   compareHealthEventsNewestFirst,
@@ -13,14 +14,20 @@ export interface TimelineEventItem {
   label: string;
   valueLabel: string;
   sourceLabel: string;
+  referenceUrl?: string;
 }
 
 export type TimelineEventsStore = HealthDbHealthEventsStore;
 
 function buildTimelineItem(event: HealthEvent): TimelineEventItem {
+  const payload = event.payload as { referenceUrl?: unknown } | undefined;
+
   return {
     event,
     ...buildHealthEventDisplay(event),
+    referenceUrl: normalizeSafeExternalUrl(
+      typeof payload?.referenceUrl === 'string' ? payload.referenceUrl : undefined
+    ),
   };
 }
 

--- a/src/lib/features/today/components/TodayPlanSurface.svelte
+++ b/src/lib/features/today/components/TodayPlanSurface.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { toSafeExternalHref } from '$lib/core/shared/external-links';
   import type { PlannedMeal } from '$lib/core/domain/types';
   import { Button, EmptyState, SectionCard } from '$lib/core/ui/primitives';
   import type { TodayEventRow, TodayPlanRow } from '$lib/features/today/model';
@@ -138,6 +139,17 @@
         <li>
           <strong>{event.label}</strong>
           <span>{event.valueLabel}</span>
+          {#if toSafeExternalHref(event.referenceUrl)}
+            <a
+              class="event-reference-link"
+              href={toSafeExternalHref(event.referenceUrl) ?? undefined}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`Learn more about same-day event ${event.label}`}
+            >
+              Learn more
+            </a>
+          {/if}
         </li>
       {/each}
     </ul>
@@ -152,6 +164,11 @@
 <style>
   .event-list {
     gap: 0.7rem;
+  }
+
+  .event-reference-link {
+    margin-left: 0.75rem;
+    color: var(--phc-label);
   }
 
   .compact-actions {

--- a/src/lib/features/today/components/TodayRecommendationSection.svelte
+++ b/src/lib/features/today/components/TodayRecommendationSection.svelte
@@ -17,6 +17,10 @@
 
   const recommendation = $derived(snapshot?.intelligence.primaryRecommendation ?? null);
   const fallbackState = $derived(snapshot?.intelligence.fallbackState ?? null);
+
+  function createSourceKindLabel(kind: string): string {
+    return kind.replace(/_/g, ' ').replace(/^./, (char) => char.toUpperCase());
+  }
 </script>
 
 <SectionCard title="Today's recommendation">
@@ -43,7 +47,10 @@
         <p class="provenance-label">Why this is showing up</p>
         <ul class="recommendation-list compact-list">
           {#each recommendation.provenance as row (row.label)}
-            <li>{row.label}</li>
+            <li>
+              <span class="provenance-pill">{createSourceKindLabel(row.sourceKind)}</span>
+              {row.label}
+            </li>
           {/each}
         </ul>
       </div>
@@ -172,6 +179,23 @@
       sans-serif;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+  }
+
+  .provenance-pill {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 0.5rem;
+    padding: 0.18rem 0.45rem;
+    border-radius: 999px;
+    border: 0.5px solid var(--phc-border-soft);
+    background: rgba(233, 195, 73, 0.08);
+    color: var(--phc-label);
+    font:
+      700 0.72rem/1 Manrope,
+      system-ui,
+      sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
 
   .compact-list {

--- a/src/lib/features/today/presentation.ts
+++ b/src/lib/features/today/presentation.ts
@@ -1,4 +1,5 @@
 import { buildHealthEventDisplay } from '$lib/core/shared/health-events';
+import { normalizeSafeExternalUrl } from '$lib/core/shared/external-links';
 import type { PlannedMeal } from '$lib/core/domain/types';
 import type { TodayConfidence, TodayRecommendationAction } from '$lib/features/today/intelligence';
 import type { TodayPlannedWorkout, TodaySnapshot } from '$lib/features/today/snapshot';
@@ -8,6 +9,7 @@ export interface TodayEventRow {
   label: string;
   valueLabel: string;
   sourceLabel: string;
+  referenceUrl?: string;
 }
 
 export interface TodayPlanRow {
@@ -74,6 +76,9 @@ export function createTodayEventRows(snapshot: TodaySnapshot | null): TodayEvent
     snapshot?.events.map((event) => ({
       id: event.id,
       ...buildHealthEventDisplay(event),
+      referenceUrl: normalizeSafeExternalUrl(
+        typeof event.payload?.referenceUrl === 'string' ? event.payload.referenceUrl : undefined
+      ),
     })) ?? []
   );
 }

--- a/src/lib/server/db/drizzle/mirror.ts
+++ b/src/lib/server/db/drizzle/mirror.ts
@@ -71,8 +71,7 @@ export function upsertMirrorRecordSync<T extends { id: string }>(
 ): void {
   const payload = toMirrorInsertRecord(tableName, record);
   const t = asTable(table);
-  db
-    .insert(table as never)
+  db.insert(table as never)
     .values(payload as never)
     .onConflictDoUpdate({
       target: t.id as never,

--- a/src/lib/server/db/drizzle/mirror.ts
+++ b/src/lib/server/db/drizzle/mirror.ts
@@ -3,6 +3,7 @@ import type { createDrizzleSqliteClient } from './client';
 import { SCHEMA_STORES } from '$lib/core/db/schema';
 
 type DrizzleDb = ReturnType<typeof createDrizzleSqliteClient>['db'];
+type DrizzleWriteDb = Pick<DrizzleDb, 'insert'>;
 
 function asTable(table: unknown): Record<string, unknown> {
   return table as Record<string, unknown>;
@@ -62,6 +63,24 @@ export async function upsertMirrorRecord<T extends { id: string }>(
     });
 }
 
+export function upsertMirrorRecordSync<T extends { id: string }>(
+  db: DrizzleWriteDb,
+  tableName: keyof typeof SCHEMA_STORES,
+  table: unknown,
+  record: T
+): void {
+  const payload = toMirrorInsertRecord(tableName, record);
+  const t = asTable(table);
+  db
+    .insert(table as never)
+    .values(payload as never)
+    .onConflictDoUpdate({
+      target: t.id as never,
+      set: payload as never,
+    })
+    .run();
+}
+
 export async function upsertMirrorRecords<T extends { id: string }>(
   db: DrizzleDb,
   tableName: keyof typeof SCHEMA_STORES,
@@ -70,6 +89,17 @@ export async function upsertMirrorRecords<T extends { id: string }>(
 ): Promise<void> {
   for (const record of records) {
     await upsertMirrorRecord(db, tableName, table, record);
+  }
+}
+
+export function upsertMirrorRecordsSync<T extends { id: string }>(
+  db: DrizzleWriteDb,
+  tableName: keyof typeof SCHEMA_STORES,
+  table: unknown,
+  records: readonly T[]
+): void {
+  for (const record of records) {
+    upsertMirrorRecordSync(db, tableName, table, record);
   }
 }
 

--- a/src/lib/server/health/clinical-tables.ts
+++ b/src/lib/server/health/clinical-tables.ts
@@ -12,7 +12,7 @@ type ClinicalTablesSearchResponse = [
   total: number,
   labels: string[],
   unknown: unknown,
-  records?: Array<[label?: string, code?: string, consumerName?: string]>
+  records?: Array<[label?: string, code?: string, consumerName?: string]>,
 ];
 
 export interface HealthSymptomSuggestion {

--- a/src/lib/server/health/clinical-tables.ts
+++ b/src/lib/server/health/clinical-tables.ts
@@ -1,0 +1,114 @@
+import {
+  createExternalSourceMetadata,
+  getExternalSourceDefinition,
+  type ExternalSourceMetadata,
+} from '$lib/core/domain/external-sources';
+import { withTimeoutInit } from '$lib/server/http/fetch-timeout';
+import { buildMedlinePlusProblemLink } from './medlineplus';
+
+const CLINICAL_TABLES_BASE_URL = 'https://clinicaltables.nlm.nih.gov/api/conditions/v3/search';
+
+type ClinicalTablesSearchResponse = [
+  total: number,
+  labels: string[],
+  unknown: unknown,
+  records?: Array<[label?: string, code?: string, consumerName?: string]>
+];
+
+export interface HealthSymptomSuggestion {
+  label: string;
+  code?: string;
+  referenceUrl?: string;
+  sourceName: string;
+}
+
+export interface HealthSymptomSuggestionResponse {
+  suggestions: HealthSymptomSuggestion[];
+  notice: string;
+  metadata: ExternalSourceMetadata;
+}
+
+export async function searchClinicalConditionSuggestions(
+  query: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<HealthSymptomSuggestion[]> {
+  const normalized = query.trim();
+  if (!normalized) {
+    return [];
+  }
+
+  const sourceName = getExternalSourceDefinition('clinical-tables-conditions').sourceName;
+  const params = new URLSearchParams({
+    terms: normalized,
+    maxList: '7',
+    sf: 'consumer_name,primary_name',
+    df: 'primary_name,icd10cm,consumer_name',
+  });
+
+  const response = await fetchImpl(
+    `${CLINICAL_TABLES_BASE_URL}?${params.toString()}`,
+    withTimeoutInit({
+      headers: {
+        accept: 'application/json',
+      },
+    })
+  );
+
+  if (!response.ok) {
+    throw new Error(`Clinical Tables request failed with ${response.status}`);
+  }
+
+  const payload = (await response.json()) as ClinicalTablesSearchResponse;
+  const records = Array.isArray(payload[3]) ? payload[3] : [];
+
+  const suggestions = records
+    .map((record): HealthSymptomSuggestion | null => {
+      if (!Array.isArray(record)) {
+        return null;
+      }
+
+      const label = typeof record?.[0] === 'string' ? record[0].trim() : '';
+      const code = typeof record?.[1] === 'string' ? record[1].trim() : '';
+
+      if (!label) {
+        return null;
+      }
+
+      return {
+        label,
+        code: code || undefined,
+        referenceUrl: buildMedlinePlusProblemLink(code, label) ?? undefined,
+        sourceName,
+      } satisfies HealthSymptomSuggestion;
+    })
+    .filter((entry): entry is HealthSymptomSuggestion => entry !== null);
+
+  return suggestions;
+}
+
+export async function searchClinicalConditionSuggestionsWithMetadata(
+  query: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<HealthSymptomSuggestionResponse> {
+  let suggestions: HealthSymptomSuggestion[];
+
+  try {
+    suggestions = await searchClinicalConditionSuggestions(query, fetchImpl);
+  } catch {
+    return {
+      suggestions: [],
+      notice: 'Clinical condition suggestions unavailable right now.',
+      metadata: createExternalSourceMetadata('clinical-tables-conditions', 'none', 'degraded'),
+    };
+  }
+
+  return {
+    suggestions,
+    notice: suggestions.length ? 'Suggestions from Clinical Tables Conditions.' : '',
+    metadata: createExternalSourceMetadata(
+      'clinical-tables-conditions',
+      suggestions.length ? 'remote-live' : 'none',
+      'none'
+    ),
+  };
+}

--- a/src/lib/server/health/medlineplus.ts
+++ b/src/lib/server/health/medlineplus.ts
@@ -1,0 +1,39 @@
+const MEDLINEPLUS_CONNECT_APPLICATION_URL = 'https://connect.medlineplus.gov/application';
+const ICD10_CODE_SYSTEM_OID = '2.16.840.1.113883.6.90';
+const RXCUI_CODE_SYSTEM_OID = '2.16.840.1.113883.6.88';
+
+export function buildMedlinePlusProblemLink(code: string, label: string): string | null {
+  const normalizedCode = code.trim();
+  const normalizedLabel = label.trim();
+
+  if (!normalizedCode || !normalizedLabel) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    'mainSearchCriteria.v.cs': ICD10_CODE_SYSTEM_OID,
+    'mainSearchCriteria.v.c': normalizedCode,
+    'mainSearchCriteria.v.dn': normalizedLabel,
+    'informationRecipient.languageCode.c': 'en',
+  });
+
+  return `${MEDLINEPLUS_CONNECT_APPLICATION_URL}?${params.toString()}`;
+}
+
+export function buildMedlinePlusMedicationLink(code: string, label: string): string | null {
+  const normalizedCode = code.trim();
+  const normalizedLabel = label.trim();
+
+  if (!normalizedCode || !normalizedLabel) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    'mainSearchCriteria.v.cs': RXCUI_CODE_SYSTEM_OID,
+    'mainSearchCriteria.v.c': normalizedCode,
+    'mainSearchCriteria.v.dn': normalizedLabel,
+    'informationRecipient.languageCode.c': 'en',
+  });
+
+  return `${MEDLINEPLUS_CONNECT_APPLICATION_URL}?${params.toString()}`;
+}

--- a/src/lib/server/health/rxnorm.ts
+++ b/src/lib/server/health/rxnorm.ts
@@ -1,0 +1,110 @@
+import {
+  createExternalSourceMetadata,
+  getExternalSourceDefinition,
+  type ExternalSourceMetadata,
+} from '$lib/core/domain/external-sources';
+import { withTimeoutInit } from '$lib/server/http/fetch-timeout';
+import { buildMedlinePlusMedicationLink } from './medlineplus';
+
+const RXNORM_APPROXIMATE_TERM_URL = 'https://rxnav.nlm.nih.gov/REST/approximateTerm.json';
+
+interface RxNormCandidate {
+  rxcui?: string;
+  name?: string;
+}
+
+interface RxNormApproximateTermResponse {
+  approximateGroup?: {
+    candidate?: RxNormCandidate[];
+  };
+}
+
+export interface HealthMedicationSuggestion {
+  label: string;
+  code?: string;
+  referenceUrl?: string;
+  sourceName: string;
+}
+
+export interface HealthMedicationSuggestionResponse {
+  suggestions: HealthMedicationSuggestion[];
+  notice: string;
+  metadata: ExternalSourceMetadata;
+}
+
+export async function searchRxNormMedicationSuggestions(
+  query: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<HealthMedicationSuggestion[]> {
+  const normalized = query.trim();
+  if (!normalized) {
+    return [];
+  }
+
+  const sourceName = getExternalSourceDefinition('rxnorm').sourceName;
+  const params = new URLSearchParams({
+    term: normalized,
+    maxEntries: '7',
+  });
+
+  const response = await fetchImpl(
+    `${RXNORM_APPROXIMATE_TERM_URL}?${params.toString()}`,
+    withTimeoutInit({
+      headers: {
+        accept: 'application/json',
+      },
+    })
+  );
+
+  if (!response.ok) {
+    throw new Error(`RxNorm request failed with ${response.status}`);
+  }
+
+  const payload = (await response.json()) as RxNormApproximateTermResponse;
+  const candidates = Array.isArray(payload.approximateGroup?.candidate)
+    ? payload.approximateGroup.candidate
+    : [];
+
+  return candidates
+    .map((candidate): HealthMedicationSuggestion | null => {
+      const label = typeof candidate.name === 'string' ? candidate.name.trim() : '';
+      const code = typeof candidate.rxcui === 'string' ? candidate.rxcui.trim() : '';
+      if (!label) {
+        return null;
+      }
+      return {
+        label,
+        code: code || undefined,
+        referenceUrl: buildMedlinePlusMedicationLink(code, label) ?? undefined,
+        sourceName,
+      };
+    })
+    .filter((candidate): candidate is HealthMedicationSuggestion => candidate !== null);
+}
+
+export async function searchRxNormMedicationSuggestionsWithMetadata(
+  query: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<HealthMedicationSuggestionResponse> {
+  let suggestions: HealthMedicationSuggestion[];
+
+  try {
+    suggestions = await searchRxNormMedicationSuggestions(query, fetchImpl);
+  } catch {
+    return {
+      suggestions: [],
+      notice: 'RxNorm suggestions unavailable right now.',
+      metadata: createExternalSourceMetadata('rxnorm', 'none', 'degraded'),
+    };
+  }
+
+  return {
+    suggestions,
+    notice: suggestions.length ? 'Suggestions from RxNorm.' : '',
+    metadata: createExternalSourceMetadata(
+      'rxnorm',
+      suggestions.length ? 'remote-live' : 'none',
+      'none'
+    ),
+  };
+}

--- a/src/lib/server/health/service.ts
+++ b/src/lib/server/health/service.ts
@@ -112,6 +112,7 @@ export async function saveSymptomPageServer(state: HealthMutationState): Promise
         symptom: state.symptomForm.symptom.trim(),
         severity,
         note: state.symptomForm.note.trim() || undefined,
+        referenceUrl: state.symptomForm.referenceUrl.trim() || undefined,
       },
       value: severity,
     })
@@ -211,6 +212,7 @@ export async function saveTemplatePageServer(state: HealthMutationState): Promis
     defaultDose: parseOptionalNumber(state.templateForm.defaultDose),
     defaultUnit: state.templateForm.defaultUnit,
     note: state.templateForm.note,
+    referenceUrl: state.templateForm.referenceUrl,
   };
 
   await upsertHealthTemplateServer(buildHealthTemplateRecord(existing, input));
@@ -247,6 +249,7 @@ export async function quickLogTemplatePageServer(
         amount: template.defaultDose,
         unit: template.defaultUnit,
         note: template.note,
+        referenceUrl: template.referenceUrl,
       },
       value: template.defaultDose,
       unit: template.defaultUnit,

--- a/src/lib/server/http/fetch-timeout.ts
+++ b/src/lib/server/http/fetch-timeout.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_REMOTE_FETCH_TIMEOUT_MS = 3000;
+
+export function withTimeoutInit(
+  init: RequestInit = {},
+  timeoutMs = DEFAULT_REMOTE_FETCH_TIMEOUT_MS
+): RequestInit {
+  return {
+    ...init,
+    signal: init.signal ?? AbortSignal.timeout(timeoutMs),
+  };
+}

--- a/src/lib/server/imports/service.ts
+++ b/src/lib/server/imports/service.ts
@@ -3,6 +3,7 @@ import type {
   HealthEvent,
   ImportArtifact,
   ImportBatch,
+  ImportPreviewResult,
   ImportSourceType,
   JournalEntry,
   OwnerProfile,
@@ -24,7 +25,9 @@ import {
   selectMirrorRecordsByField,
   selectMirrorRecordsByFieldValues,
   upsertMirrorRecord,
+  upsertMirrorRecordSync,
   upsertMirrorRecords,
+  upsertMirrorRecordsSync,
 } from '$lib/server/db/drizzle/mirror';
 import { refreshWeeklyReviewArtifactsForDaysServer } from '$lib/server/review/service';
 import {
@@ -80,6 +83,30 @@ async function stageArtifacts(input: {
   await upsertMirrorRecords(db, 'importArtifacts', drizzleSchema.importArtifacts, artifacts);
 }
 
+function stageArtifactsSync(input: {
+  db: Parameters<typeof upsertMirrorRecordSync>[0];
+  batchId: string;
+  artifactType: 'healthEvent' | 'journalEntry';
+  records: Array<HealthEvent | JournalEntry>;
+}): void {
+  const timestamp = nowIso();
+
+  const artifacts: ImportArtifact[] = input.records.map((record) => ({
+    ...createRecordMeta(createRecordId('import-artifact'), timestamp),
+    batchId: input.batchId,
+    artifactType: input.artifactType,
+    fingerprint: textFingerprint(JSON.stringify(record)),
+    payload: record as unknown as Record<string, unknown>,
+  }));
+
+  upsertMirrorRecordsSync(
+    input.db,
+    'importArtifacts',
+    drizzleSchema.importArtifacts,
+    artifacts
+  );
+}
+
 export async function listImportBatchesServer(): Promise<ImportBatch[]> {
   const { db } = getServerDrizzleClient();
   return (await selectAllMirrorRecords<ImportBatch>(db, drizzleSchema.importBatches)).sort(
@@ -124,6 +151,26 @@ export async function dedupeImportedEventsServer(
   return { adds, duplicates };
 }
 
+export async function dedupeImportedJournalEntriesServer(
+  entries: JournalEntry[]
+): Promise<{ adds: JournalEntry[]; duplicates: JournalEntry[] }> {
+  const { db } = getServerDrizzleClient();
+  const adds: JournalEntry[] = [];
+  const duplicates: JournalEntry[] = [];
+
+  for (const entry of entries) {
+    const existing = await selectMirrorRecordById<JournalEntry>(db, drizzleSchema.journalEntries, entry.id);
+
+    if (existing) {
+      duplicates.push(entry);
+    } else {
+      adds.push(entry);
+    }
+  }
+
+  return { adds, duplicates };
+}
+
 async function stageHealthEventBatch(
   sourceType: Extract<
     ImportSourceType,
@@ -131,34 +178,24 @@ async function stageHealthEventBatch(
   >,
   events: HealthEvent[],
   analysis: ImportPayloadAnalysis | null
-): Promise<ImportBatch> {
-  const { db } = getServerDrizzleClient();
+): Promise<ImportPreviewResult> {
   const { adds, duplicates } = await dedupeImportedEventsServer(events);
-  const batch = await createImportBatchServer(sourceType);
-  await stageArtifacts({
-    batchId: batch.id,
-    artifactType: 'healthEvent',
-    records: adds,
-  });
-
-  const staged: ImportBatch = {
-    ...batch,
+  return {
+    sourceType,
+    status: 'preview',
     summary: {
       adds: adds.length,
       duplicates: duplicates.length,
       warnings: warningCount(analysis),
     },
   };
-  await upsertMirrorRecord(db, 'importBatches', drizzleSchema.importBatches, staged);
-  return staged;
 }
 
 export async function previewImportServer(input: {
   sourceType: ImportSourceType;
   rawText: string;
   ownerProfile?: OwnerProfile | null;
-}): Promise<ImportBatch> {
-  const { db } = getServerDrizzleClient();
+}): Promise<ImportPreviewResult> {
   const analysis = analyzeImportPayload(input.rawText);
   const resolvedSourceType = analysis?.sourceType ?? input.sourceType;
 
@@ -193,64 +230,105 @@ export async function previewImportServer(input: {
   }
 
   const parsedEntries = analysis?.journalEntries ?? parseDayOneExport(input.rawText);
-  const batch = await createImportBatchServer(resolvedSourceType);
-  await stageArtifacts({
-    batchId: batch.id,
-    artifactType: 'journalEntry',
-    records: parsedEntries,
-  });
-
-  const staged: ImportBatch = {
-    ...batch,
+  const { adds, duplicates } = await dedupeImportedJournalEntriesServer(parsedEntries);
+  return {
+    sourceType: resolvedSourceType,
+    status: 'preview',
     summary: {
-      adds: parsedEntries.length,
-      duplicates: 0,
+      adds: adds.length,
+      duplicates: duplicates.length,
       warnings: warningCount(analysis),
     },
   };
-  await upsertMirrorRecord(db, 'importBatches', drizzleSchema.importBatches, staged);
-  return staged;
 }
 
-export async function commitImportBatchServer(batchId: string): Promise<ImportBatch> {
+export async function commitImportBatchServer(input: {
+  sourceType: ImportSourceType;
+  rawText: string;
+  ownerProfile?: OwnerProfile | null;
+}): Promise<ImportBatch> {
   const { db } = getServerDrizzleClient();
-  const batch = await selectMirrorRecordById<ImportBatch>(db, drizzleSchema.importBatches, batchId);
-  if (!batch) {
-    throw new Error('Import batch not found');
-  }
-
-  const artifacts = await selectMirrorRecordsByField<ImportArtifact>(
-    db,
-    drizzleSchema.importArtifacts,
-    'batchId',
-    batchId
-  );
+  const analysis = analyzeImportPayload(input.rawText);
+  const resolvedSourceType = analysis?.sourceType ?? input.sourceType;
+  const timestamp = nowIso();
+  const batch: ImportBatch = {
+    ...createRecordMeta(createRecordId('import-batch'), timestamp),
+    sourceType: resolvedSourceType,
+    status: 'staged',
+  };
   const affectedDays = new Set<string>();
-  const healthEvents: HealthEvent[] = [];
-  const journalEntries: JournalEntry[] = [];
+  let healthEvents: HealthEvent[] = [];
+  let journalEntries: JournalEntry[] = [];
+  let adds = 0;
+  let duplicates = 0;
 
-  for (const artifact of artifacts) {
-    if (artifact.artifactType === 'healthEvent' && artifact.payload) {
-      const event = structuredClone(artifact.payload) as unknown as HealthEvent;
-      healthEvents.push(event);
-      affectedDays.add(event.localDay);
+  if (resolvedSourceType === 'apple-health-xml') {
+    const parsed = analysis?.healthEvents ?? parseAppleHealthXml(input.rawText);
+    const deduped = await dedupeImportedEventsServer(parsed);
+    healthEvents = deduped.adds;
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
+  } else if (resolvedSourceType === 'healthkit-companion') {
+    const parsed = analysis?.healthEvents ?? importHealthKitCompanionBundle(input.rawText).events;
+    const deduped = await dedupeImportedEventsServer(parsed);
+    healthEvents = deduped.adds;
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
+  } else if (resolvedSourceType === 'smart-fhir-sandbox') {
+    if (!input.ownerProfile) {
+      throw new Error(
+        'Configure your owner profile in Settings before previewing SMART clinical imports.'
+      );
     }
 
-    if (artifact.artifactType === 'journalEntry' && artifact.payload) {
-      journalEntries.push(structuredClone(artifact.payload) as unknown as JournalEntry);
+    const normalized = analysis ?? analyzeImportPayload(input.rawText);
+    const imported = resolveSmartClinicalImport(normalized, input.rawText);
+    const match = resolveClinicalPatientMatch(imported.patientIdentity, [
+      ownerCandidate(input.ownerProfile),
+    ]);
+
+    if (match.status !== 'exact') {
+      throw new Error(match.reason);
     }
+
+    const deduped = await dedupeImportedEventsServer(imported.events);
+    healthEvents = deduped.adds;
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
+  } else {
+    const parsed = analysis?.journalEntries ?? parseDayOneExport(input.rawText);
+    const deduped = await dedupeImportedJournalEntriesServer(parsed);
+    journalEntries = deduped.adds;
+    adds = deduped.adds.length;
+    duplicates = deduped.duplicates.length;
   }
-
-  await upsertMirrorRecords(db, 'healthEvents', drizzleSchema.healthEvents, healthEvents);
-  await upsertMirrorRecords(db, 'journalEntries', drizzleSchema.journalEntries, journalEntries);
 
   const committed: ImportBatch = {
     ...batch,
     ...updateRecordMeta(batch, batch.id, nowIso()),
     status: 'committed',
+    summary: {
+      adds,
+      duplicates,
+      warnings: warningCount(analysis),
+    },
   };
 
-  await upsertMirrorRecord(db, 'importBatches', drizzleSchema.importBatches, committed);
+  db.transaction((tx) => {
+    upsertMirrorRecordsSync(tx, 'healthEvents', drizzleSchema.healthEvents, healthEvents);
+    upsertMirrorRecordsSync(tx, 'journalEntries', drizzleSchema.journalEntries, journalEntries);
+    stageArtifactsSync({
+      db: tx,
+      batchId: batch.id,
+      artifactType: healthEvents.length ? 'healthEvent' : 'journalEntry',
+      records: healthEvents.length ? healthEvents : journalEntries,
+    });
+    upsertMirrorRecordSync(tx, 'importBatches', drizzleSchema.importBatches, committed);
+  });
+
+  for (const event of healthEvents) {
+    affectedDays.add(event.localDay);
+  }
 
   if (affectedDays.size > 0) {
     await refreshWeeklyReviewArtifactsForDaysServer([...affectedDays]);

--- a/src/lib/server/imports/service.ts
+++ b/src/lib/server/imports/service.ts
@@ -46,6 +46,11 @@ function ownerCandidate(ownerProfile: OwnerProfile): LocalPatientCandidate {
   };
 }
 
+function normalizeSourceRecordId(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
 function resolveSmartClinicalImport(
   analysis: ImportPayloadAnalysis | null,
   rawText: string
@@ -99,12 +104,7 @@ function stageArtifactsSync(input: {
     payload: record as unknown as Record<string, unknown>,
   }));
 
-  upsertMirrorRecordsSync(
-    input.db,
-    'importArtifacts',
-    drizzleSchema.importArtifacts,
-    artifacts
-  );
+  upsertMirrorRecordsSync(input.db, 'importArtifacts', drizzleSchema.importArtifacts, artifacts);
 }
 
 export async function listImportBatchesServer(): Promise<ImportBatch[]> {
@@ -130,22 +130,40 @@ export async function dedupeImportedEventsServer(
   events: HealthEvent[]
 ): Promise<{ adds: HealthEvent[]; duplicates: HealthEvent[] }> {
   const { db } = getServerDrizzleClient();
+  const candidateSourceRecordIds = events
+    .map((event) => normalizeSourceRecordId(event.sourceRecordId))
+    .filter((value): value is string => value !== null);
+
   const existing = await selectMirrorRecordsByFieldValues<HealthEvent>(
     db,
     drizzleSchema.healthEvents,
     'sourceRecordId',
-    events.map((event) => event.sourceRecordId ?? '')
+    candidateSourceRecordIds
   );
-  const existingIds = new Set(existing.map((event) => event.sourceRecordId ?? ''));
+
+  const seenSourceRecordIds = new Set(
+    existing
+      .map((event) => normalizeSourceRecordId(event.sourceRecordId))
+      .filter((value): value is string => value !== null)
+  );
+
   const adds: HealthEvent[] = [];
   const duplicates: HealthEvent[] = [];
 
   for (const event of events) {
-    if (existingIds.has(event.sourceRecordId ?? '')) {
-      duplicates.push(event);
-    } else {
+    const sourceRecordId = normalizeSourceRecordId(event.sourceRecordId);
+    if (!sourceRecordId) {
       adds.push(event);
+      continue;
     }
+
+    if (seenSourceRecordIds.has(sourceRecordId)) {
+      duplicates.push(event);
+      continue;
+    }
+
+    seenSourceRecordIds.add(sourceRecordId);
+    adds.push(event);
   }
 
   return { adds, duplicates };
@@ -159,7 +177,11 @@ export async function dedupeImportedJournalEntriesServer(
   const duplicates: JournalEntry[] = [];
 
   for (const entry of entries) {
-    const existing = await selectMirrorRecordById<JournalEntry>(db, drizzleSchema.journalEntries, entry.id);
+    const existing = await selectMirrorRecordById<JournalEntry>(
+      db,
+      drizzleSchema.journalEntries,
+      entry.id
+    );
 
     if (existing) {
       duplicates.push(entry);

--- a/src/lib/server/movement/service.ts
+++ b/src/lib/server/movement/service.ts
@@ -1,6 +1,7 @@
 import type { ExerciseCatalogItem } from '$lib/core/domain/types';
 import { createWorkoutTemplateForm, normalizeExerciseDrafts } from '$lib/features/movement/model';
 import { createMovementPageState, type MovementPageState } from '$lib/features/movement/controller';
+import { searchExerciseCatalog } from '$lib/features/movement/service';
 import { searchWgerExercises } from '$lib/server/movement/wger';
 import { getServerDrizzleClient } from '$lib/server/db/drizzle/client';
 import { drizzleSchema } from '$lib/server/db/drizzle/schema';
@@ -47,7 +48,23 @@ export async function searchMovementExercisesServer(query: string): Promise<Exer
     return [];
   }
 
-  const results = await searchWgerExercises(normalizedQuery);
+  const cachedMatches = searchExerciseCatalog(normalizedQuery, await listExerciseCatalogItemsServer());
+  if (cachedMatches.length) {
+    return cachedMatches;
+  }
+
+  const results = await (async (): Promise<ExerciseCatalogItem[] | null> => {
+    try {
+      return await searchWgerExercises(normalizedQuery);
+    } catch {
+      return null;
+    }
+  })();
+
+  if (!results?.length) {
+    return [];
+  }
+
   const { db } = getServerDrizzleClient();
 
   for (const item of results) {

--- a/src/lib/server/movement/service.ts
+++ b/src/lib/server/movement/service.ts
@@ -48,7 +48,10 @@ export async function searchMovementExercisesServer(query: string): Promise<Exer
     return [];
   }
 
-  const cachedMatches = searchExerciseCatalog(normalizedQuery, await listExerciseCatalogItemsServer());
+  const cachedMatches = searchExerciseCatalog(
+    normalizedQuery,
+    await listExerciseCatalogItemsServer()
+  );
   if (cachedMatches.length) {
     return cachedMatches;
   }

--- a/src/lib/server/movement/wger.ts
+++ b/src/lib/server/movement/wger.ts
@@ -1,5 +1,6 @@
 import type { ExerciseCatalogItem } from '$lib/core/domain/types';
 import { z } from 'zod';
+import { withTimeoutInit } from '$lib/server/http/fetch-timeout';
 
 type WgerEntity = Record<string, unknown>;
 
@@ -128,11 +129,14 @@ async function requestExercises(
   url.searchParams.set('ordering', 'name');
   url.searchParams.set(searchParam, query);
 
-  const response = await fetchImpl(url, {
-    headers: {
-      accept: 'application/json',
-    },
-  });
+  const response = await fetchImpl(
+    url,
+    withTimeoutInit({
+      headers: {
+        accept: 'application/json',
+      },
+    })
+  );
 
   if (!response.ok) {
     throw new Error(`wger request failed with ${response.status}`);

--- a/src/lib/server/nutrition/open-food-facts.ts
+++ b/src/lib/server/nutrition/open-food-facts.ts
@@ -1,6 +1,7 @@
 import { nowIso } from '$lib/core/domain/time';
 import type { BaseRecord, FoodCatalogItem } from '$lib/core/domain/types';
 import { updateRecordMeta } from '$lib/core/shared/records';
+import { withTimeoutInit } from '$lib/server/http/fetch-timeout';
 
 const OPEN_FOOD_FACTS_BASE_URL = 'https://world.openfoodfacts.org';
 const OPEN_FOOD_FACTS_SOURCE_NAME = 'Open Food Facts';
@@ -101,6 +102,8 @@ export function normalizeOpenFoodFactsProduct(
     sourceName: OPEN_FOOD_FACTS_SOURCE_NAME,
     brandName: firstBrand(product.brands),
     barcode,
+    imageUrl: product.image_front_small_url ?? product.image_url,
+    ingredientsText: product.ingredients_text?.trim() || undefined,
     calories: coerceNumber(
       product.nutriments?.['energy-kcal_100g'] ?? product.nutriments?.['energy-kcal']
     ),
@@ -114,9 +117,12 @@ export function normalizeOpenFoodFactsProduct(
 }
 
 async function readJson<T>(url: string, fetchImpl: typeof fetch = fetch): Promise<T> {
-  const response = await fetchImpl(url, {
-    headers: openFoodFactsHeaders(),
-  });
+  const response = await fetchImpl(
+    url,
+    withTimeoutInit({
+      headers: openFoodFactsHeaders(),
+    })
+  );
 
   if (!response.ok) {
     throw new Error(`Open Food Facts request failed with ${response.status}`);

--- a/src/lib/server/nutrition/search-service.ts
+++ b/src/lib/server/nutrition/search-service.ts
@@ -30,11 +30,26 @@ import {
 import { getServerDrizzleClient } from '$lib/server/db/drizzle/client';
 import { drizzleSchema } from '$lib/server/db/drizzle/schema';
 import { selectMirrorRecordById } from '$lib/server/db/drizzle/mirror';
+import {
+  createExternalSourceMetadata,
+  type ExternalSourceMetadata,
+} from '$lib/core/domain/external-sources';
 
-export type SearchUsdaResponse = {
-  matches: FoodLookupResult[];
+export interface SourceSearchResponse<T> {
+  matches: T[];
   notice?: string;
-};
+  metadata: ExternalSourceMetadata;
+}
+
+export interface SourceLookupResponse<T> {
+  match: T | null;
+  notice?: string;
+  metadata: ExternalSourceMetadata;
+}
+
+export type SearchUsdaResponse = SourceSearchResponse<FoodLookupResult>;
+export type SearchPackagedResponse = SourceSearchResponse<FoodLookupResult>;
+export type BarcodeLookupResponse = SourceLookupResponse<FoodLookupResult>;
 
 function dedupeLookupResults(items: FoodLookupResult[]): FoodLookupResult[] {
   const deduped = new Map<string, FoodLookupResult>();
@@ -52,10 +67,21 @@ function dedupeRecipesById(items: RecipeCatalogItem[]): RecipeCatalogItem[] {
   return [...deduped.values()];
 }
 
-export async function searchPackagedFoodsServer(query: string): Promise<FoodLookupResult[]> {
+function usdaLocalCatalogItems(items: FoodCatalogItem[]): FoodCatalogItem[] {
+  return items.filter((item) => item.sourceType === 'usda-fallback');
+}
+
+function openFoodFactsCatalogItems(items: FoodCatalogItem[]): FoodCatalogItem[] {
+  return items.filter((item) => item.sourceType === 'open-food-facts');
+}
+
+export async function searchPackagedFoodsServer(query: string): Promise<SearchPackagedResponse> {
   const normalizedQuery = query.trim();
   if (!normalizedQuery) {
-    return [];
+    return {
+      matches: [],
+      metadata: createExternalSourceMetadata('open-food-facts', 'none', 'none'),
+    };
   }
 
   const catalogItems = await listFoodCatalogItemsServer();
@@ -68,7 +94,11 @@ export async function searchPackagedFoodsServer(query: string): Promise<FoodLook
     }
   })();
   if (!remoteProducts) {
-    return localMatches;
+    return {
+      matches: localMatches,
+      notice: 'Open Food Facts search unavailable, using local packaged foods.',
+      metadata: createExternalSourceMetadata('open-food-facts', 'local-cache', 'degraded'),
+    };
   }
 
   const remoteMatches: FoodLookupResult[] = [];
@@ -80,30 +110,63 @@ export async function searchPackagedFoodsServer(query: string): Promise<FoodLook
     remoteMatches.push(foodLookupResultFromCatalogItem(cached));
   }
 
-  return dedupeLookupResults([...localMatches, ...remoteMatches]);
+  const matches = dedupeLookupResults([...localMatches, ...remoteMatches]);
+
+  return {
+    matches,
+    metadata: createExternalSourceMetadata(
+      'open-food-facts',
+      remoteMatches.length > 0 ? 'remote-live' : localMatches.length > 0 ? 'local-cache' : 'none',
+      'none'
+    ),
+  };
 }
 
 export async function searchUsdaFoodsServer(query: string): Promise<SearchUsdaResponse> {
   const normalizedQuery = query.trim();
   if (!normalizedQuery) {
-    return { matches: [] };
+    return {
+      matches: [],
+      metadata: createExternalSourceMetadata('usda-fooddata-central', 'none', 'none'),
+    };
   }
 
   const catalogItems = await listFoodCatalogItemsServer();
-  const localMatches = searchLocalFoodCatalog(normalizedQuery, catalogItems);
+  const localMatches = searchLocalFoodCatalog(normalizedQuery, usdaLocalCatalogItems(catalogItems));
   const apiKey = process.env.USDA_FDC_API_KEY ?? process.env.FDC_API_KEY;
 
   if (!apiKey) {
     return {
-      matches: searchFoodData(normalizedQuery, catalogItems),
+      matches: searchFoodData(normalizedQuery, usdaLocalCatalogItems(catalogItems)),
       notice: 'USDA live search unavailable, using local fallback foods.',
+      metadata: createExternalSourceMetadata('usda-fooddata-central', 'local-cache', 'degraded'),
     };
   }
 
-  const remoteMatches = await searchUsdaFoods(normalizedQuery, apiKey);
+  const remoteMatches = await (async () => {
+    try {
+      return await searchUsdaFoods(normalizedQuery, apiKey);
+    } catch {
+      return null;
+    }
+  })();
+
+  if (!remoteMatches) {
+    return {
+      matches: searchFoodData(normalizedQuery, usdaLocalCatalogItems(catalogItems)),
+      notice: 'USDA live search unavailable, using local fallback foods.',
+      metadata: createExternalSourceMetadata('usda-fooddata-central', 'local-cache', 'degraded'),
+    };
+  }
+
   return {
     matches: dedupeLookupResults([...localMatches, ...remoteMatches]),
     notice: remoteMatches.length ? '' : 'No USDA matches found, showing local results only.',
+    metadata: createExternalSourceMetadata(
+      'usda-fooddata-central',
+      remoteMatches.length > 0 ? 'remote-live' : localMatches.length > 0 ? 'local-cache' : 'none',
+      'none'
+    ),
   };
 }
 
@@ -134,16 +197,23 @@ export async function searchRecipesServer(query: string): Promise<RecipeCatalogI
   return dedupeRecipesById([...localMatches, ...cachedRemoteMatches]);
 }
 
-export async function lookupNutritionBarcodeServer(code: string): Promise<FoodLookupResult | null> {
+export async function lookupNutritionBarcodeServer(code: string): Promise<BarcodeLookupResponse> {
   const barcode = normalizeOpenFoodFactsBarcode(code);
   if (!barcode) {
-    return null;
+    return {
+      match: null,
+      metadata: createExternalSourceMetadata('open-food-facts', 'none', 'none'),
+    };
   }
 
   const catalogItems = await listFoodCatalogItemsServer();
-  const local = findFoodCatalogItemByBarcode(barcode, catalogItems);
+  const local = findFoodCatalogItemByBarcode(barcode, openFoodFactsCatalogItems(catalogItems));
   if (local) {
-    return local;
+    return {
+      match: local,
+      notice: 'Packaged food loaded from local cache.',
+      metadata: createExternalSourceMetadata('open-food-facts', 'local-cache', 'none'),
+    };
   }
 
   let product: Awaited<ReturnType<typeof fetchOpenFoodFactsProductByBarcode>>;
@@ -151,15 +221,32 @@ export async function lookupNutritionBarcodeServer(code: string): Promise<FoodLo
   try {
     product = await fetchOpenFoodFactsProductByBarcode(barcode);
   } catch {
-    return null;
+    return {
+      match: null,
+      metadata: createExternalSourceMetadata('open-food-facts', 'none', 'degraded'),
+    };
   }
 
-  if (!product) return null;
+  if (!product) {
+    return {
+      match: null,
+      metadata: createExternalSourceMetadata('open-food-facts', 'none', 'none'),
+    };
+  }
 
   const normalized = normalizeOpenFoodFactsProduct(product);
-  if (!normalized) return null;
+  if (!normalized) {
+    return {
+      match: null,
+      metadata: createExternalSourceMetadata('open-food-facts', 'none', 'degraded'),
+    };
+  }
 
-  return foodLookupResultFromCatalogItem(await upsertFoodCatalogItemServer(normalized));
+  return {
+    match: foodLookupResultFromCatalogItem(await upsertFoodCatalogItemServer(normalized)),
+    notice: 'Packaged food loaded from Open Food Facts.',
+    metadata: createExternalSourceMetadata('open-food-facts', 'remote-live', 'none'),
+  };
 }
 
 export async function enrichNutritionFoodServer(fdcId: string): Promise<FoodLookupResult> {

--- a/src/lib/server/nutrition/service.ts
+++ b/src/lib/server/nutrition/service.ts
@@ -10,8 +10,10 @@ export {
   saveNutritionRecurringMealServer,
 } from '$lib/server/nutrition/meal-mutations';
 export {
+  type BarcodeLookupResponse,
   enrichNutritionFoodServer,
   lookupNutritionBarcodeServer,
+  type SearchPackagedResponse,
   searchPackagedFoodsServer,
   searchRecipesServer,
   searchUsdaFoodsServer,

--- a/src/lib/server/nutrition/usda.ts
+++ b/src/lib/server/nutrition/usda.ts
@@ -1,6 +1,7 @@
 import { nowIso } from '$lib/core/domain/time';
 import type { BaseRecord, FoodCatalogItem } from '$lib/core/domain/types';
 import { updateRecordMeta } from '$lib/core/shared/records';
+import { withTimeoutInit } from '$lib/server/http/fetch-timeout';
 
 const USDA_SOURCE_NAME = 'USDA FoodData Central';
 const USDA_BASE_URL = 'https://api.nal.usda.gov/fdc/v1';
@@ -148,7 +149,7 @@ async function readJson<T>(
   init: RequestInit,
   fetchImpl: typeof fetch = fetch
 ): Promise<T> {
-  const response = await fetchImpl(url, init);
+  const response = await fetchImpl(url, withTimeoutInit(init));
 
   if (!response.ok) {
     throw new Error(`USDA request failed with ${response.status}`);

--- a/src/lib/server/timeline/service.ts
+++ b/src/lib/server/timeline/service.ts
@@ -1,4 +1,5 @@
 import type { HealthEvent, SourceType } from '$lib/core/domain/types';
+import { normalizeSafeExternalUrl } from '$lib/core/shared/external-links';
 import {
   buildHealthEventDisplay,
   compareHealthEventsNewestFirst,
@@ -15,12 +16,18 @@ export interface TimelineEventItem {
   label: string;
   valueLabel: string;
   sourceLabel: string;
+  referenceUrl?: string;
 }
 
 function buildTimelineItem(event: HealthEvent): TimelineEventItem {
+  const payload = event.payload as { referenceUrl?: unknown } | undefined;
+
   return {
     event,
     ...buildHealthEventDisplay(event),
+    referenceUrl: normalizeSafeExternalUrl(
+      typeof payload?.referenceUrl === 'string' ? payload.referenceUrl : undefined
+    ),
   };
 }
 

--- a/src/routes/api/health/search-medications/+server.ts
+++ b/src/routes/api/health/search-medications/+server.ts
@@ -1,0 +1,46 @@
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { searchRxNormMedicationSuggestionsWithMetadata } from '$lib/server/health/rxnorm';
+import { createExternalSourceMetadata } from '$lib/core/domain/external-sources';
+
+const medicationSearchRequestSchema = z.object({
+  query: z.string(),
+});
+
+export const POST: RequestHandler = async ({ request }) => {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('Invalid medication search request payload.', { status: 400 });
+  }
+
+  const parsed = medicationSearchRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response('Invalid medication search request payload.', { status: 400 });
+  }
+
+  const query = parsed.data.query.trim();
+  if (!query) {
+    return Response.json({
+      suggestions: [],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    });
+  }
+
+  try {
+    return Response.json(await searchRxNormMedicationSuggestionsWithMetadata(query));
+  } catch {
+    return Response.json({
+      suggestions: [],
+      notice: 'RxNorm suggestions unavailable right now.',
+      metadata: createExternalSourceMetadata('rxnorm', 'none', 'degraded'),
+    });
+  }
+};

--- a/src/routes/api/health/search-symptoms/+server.ts
+++ b/src/routes/api/health/search-symptoms/+server.ts
@@ -1,0 +1,46 @@
+import type { RequestHandler } from './$types';
+import { z } from 'zod';
+import { searchClinicalConditionSuggestionsWithMetadata } from '$lib/server/health/clinical-tables';
+import { createExternalSourceMetadata } from '$lib/core/domain/external-sources';
+
+const symptomSearchRequestSchema = z.object({
+  query: z.string(),
+});
+
+export const POST: RequestHandler = async ({ request }) => {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return new Response('Invalid symptom search request payload.', { status: 400 });
+  }
+
+  const parsed = symptomSearchRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return new Response('Invalid symptom search request payload.', { status: 400 });
+  }
+
+  const query = parsed.data.query.trim();
+  if (!query) {
+    return Response.json({
+      suggestions: [],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    });
+  }
+
+  try {
+    return Response.json(await searchClinicalConditionSuggestionsWithMetadata(query));
+  } catch {
+    return Response.json({
+      suggestions: [],
+      notice: 'Clinical condition suggestions unavailable right now.',
+      metadata: createExternalSourceMetadata('clinical-tables-conditions', 'none', 'degraded'),
+    });
+  }
+};

--- a/src/routes/api/imports/+server.ts
+++ b/src/routes/api/imports/+server.ts
@@ -13,7 +13,7 @@ export const POST: RequestHandler = createValidatedActionPostHandler({
   handlers: {
     list: async () => await listImportBatchesServer(),
     preview: async (data) => await previewImportServer(data.input),
-    commit: async (data) => await commitImportBatchServer(data.batchId),
+    commit: async (data) => await commitImportBatchServer(data.input),
   },
   onError: (error) => {
     const message = error instanceof Error ? error.message : 'Import request failed.';

--- a/src/routes/api/nutrition/barcode/[code]/+server.ts
+++ b/src/routes/api/nutrition/barcode/[code]/+server.ts
@@ -1,9 +1,8 @@
 import type { RequestHandler } from './$types';
-import type { FoodLookupResult } from '$lib/features/nutrition/types';
 import { lookupNutritionBarcodeServer } from '$lib/server/nutrition/service';
 
 export const POST: RequestHandler = async ({ params }) => {
   return Response.json(
-    (await lookupNutritionBarcodeServer(params.code ?? '')) satisfies FoodLookupResult | null
+    await lookupNutritionBarcodeServer(params.code ?? '')
   );
 };

--- a/src/routes/api/nutrition/barcode/[code]/+server.ts
+++ b/src/routes/api/nutrition/barcode/[code]/+server.ts
@@ -2,7 +2,5 @@ import type { RequestHandler } from './$types';
 import { lookupNutritionBarcodeServer } from '$lib/server/nutrition/service';
 
 export const POST: RequestHandler = async ({ params }) => {
-  return Response.json(
-    await lookupNutritionBarcodeServer(params.code ?? '')
-  );
+  return Response.json(await lookupNutritionBarcodeServer(params.code ?? ''));
 };

--- a/src/routes/api/nutrition/search-packaged/+server.ts
+++ b/src/routes/api/nutrition/search-packaged/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from './$types';
-import type { FoodLookupResult } from '$lib/features/nutrition/types';
 import { nutritionQueryRequestSchema } from '$lib/features/nutrition/contracts';
+import type { SearchPackagedResponse } from '$lib/server/nutrition/service';
 import { searchPackagedFoodsServer } from '$lib/server/nutrition/service';
 
 export const POST: RequestHandler = async ({ request }) => {
@@ -19,7 +19,14 @@ export const POST: RequestHandler = async ({ request }) => {
 
   const query = parsed.data.query?.trim() ?? '';
   if (!query) {
-    return Response.json([] satisfies FoodLookupResult[]);
+    return Response.json({
+      matches: [],
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    } satisfies SearchPackagedResponse);
   }
 
   return Response.json(await searchPackagedFoodsServer(query));

--- a/src/routes/api/nutrition/search-usda/+server.ts
+++ b/src/routes/api/nutrition/search-usda/+server.ts
@@ -19,7 +19,14 @@ export const POST: RequestHandler = async ({ request }) => {
 
   const query = parsed.data.query?.trim() ?? '';
   if (!query) {
-    return Response.json({ matches: [] } satisfies SearchUsdaResponse);
+    return Response.json({
+      matches: [],
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    } satisfies SearchUsdaResponse);
   }
 
   return Response.json(await searchUsdaFoodsServer(query));

--- a/tests/core/unit/domain/external-sources.test.ts
+++ b/tests/core/unit/domain/external-sources.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXTERNAL_SOURCE_REGISTRY,
+  getExternalSourceDefinition,
+} from '$lib/core/domain/external-sources';
+
+describe('external source registry', () => {
+  it('registers the first-wave production sources with stable posture', () => {
+    expect(getExternalSourceDefinition('usda-fooddata-central')).toMatchObject({
+      id: 'usda-fooddata-central',
+      category: 'nutrition',
+      authMode: 'api-key',
+      productionPosture: 'adopt',
+    });
+
+    expect(getExternalSourceDefinition('open-food-facts')).toMatchObject({
+      id: 'open-food-facts',
+      category: 'nutrition',
+      authMode: 'none',
+      productionPosture: 'adopt',
+    });
+
+    expect(getExternalSourceDefinition('wger')).toMatchObject({
+      id: 'wger',
+      category: 'movement',
+      authMode: 'none',
+      productionPosture: 'adopt',
+    });
+  });
+
+  it('keeps later or seed-only sources out of the adopt-now tier', () => {
+    expect(getExternalSourceDefinition('themealdb')).toMatchObject({
+      productionPosture: 'optional',
+    });
+    expect(getExternalSourceDefinition('blue-button')).toMatchObject({
+      productionPosture: 'later',
+    });
+  });
+
+  it('exposes the registry as a stable list for manifests and UI surfaces', () => {
+    expect(EXTERNAL_SOURCE_REGISTRY.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining([
+        'usda-fooddata-central',
+        'open-food-facts',
+        'wger',
+        'smart-fhir-sandbox',
+        'healthkit-companion',
+      ])
+    );
+  });
+});

--- a/tests/features/component/health/HealthEventStreamSection.spec.ts
+++ b/tests/features/component/health/HealthEventStreamSection.spec.ts
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import HealthEventStreamSection from '../../../../src/lib/features/health/components/HealthEventStreamSection.svelte';
+import type { HealthEventRow } from '$lib/features/health/model';
+
+describe('HealthEventStreamSection', () => {
+  it('renders a learn-more link for safe symptom reference urls', () => {
+    const eventRows: HealthEventRow[] = [
+      {
+        id: 'symptom-1',
+        title: 'Headache',
+        badge: 'Severity 4/5',
+        lines: ['After lunch'],
+        meta: 'Manual · 3:00 PM',
+        referenceUrl:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+      },
+    ];
+
+    render(HealthEventStreamSection, { eventRows });
+
+    expect(
+      screen.getByRole('link', { name: /learn more about logged medication headache/i })
+    ).toHaveProperty(
+      'href',
+      'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en'
+    );
+  });
+
+  it('does not render learn-more links for unsafe reference urls', () => {
+    const eventRows: HealthEventRow[] = [
+      {
+        id: 'symptom-unsafe',
+        title: 'Unsafe symptom',
+        badge: 'Severity 3/5',
+        lines: [],
+        meta: 'Manual · 3:00 PM',
+        referenceUrl: 'javascript:alert(1)',
+      },
+    ];
+
+    render(HealthEventStreamSection, { eventRows });
+
+    expect(screen.queryByRole('link', { name: /learn more/i })).toBeNull();
+  });
+});

--- a/tests/features/component/health/HealthManualLoggingSection.spec.ts
+++ b/tests/features/component/health/HealthManualLoggingSection.spec.ts
@@ -54,7 +54,9 @@ describe('HealthManualLoggingSection', () => {
     expect(screen.getByText(/Sources: Clinical Tables Conditions/i)).toBeTruthy();
     expect(screen.getByText(/Cache: remote-live/i)).toBeTruthy();
     expect(screen.getByText(/Status: none/i)).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Learn more about Headache' }).getAttribute('href')).toBe(
+    expect(
+      screen.getByRole('link', { name: 'Learn more about Headache' }).getAttribute('href')
+    ).toBe(
       'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en'
     );
     await fireEvent.click(screen.getByRole('button', { name: 'Use symptom Headache' }));

--- a/tests/features/component/health/HealthManualLoggingSection.spec.ts
+++ b/tests/features/component/health/HealthManualLoggingSection.spec.ts
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import HealthManualLoggingSection from '../../../../src/lib/features/health/components/HealthManualLoggingSection.svelte';
+import {
+  createAnxietyForm,
+  createSleepNoteForm,
+  createSymptomForm,
+  type HealthSymptomSuggestion,
+} from '$lib/features/health/model';
+
+describe('HealthManualLoggingSection', () => {
+  it('renders symptom suggestions and applies a selected suggestion to the symptom field', async () => {
+    const onSymptomFieldChange = vi.fn();
+
+    render(HealthManualLoggingSection, {
+      symptomForm: createSymptomForm(),
+      anxietyForm: createAnxietyForm(),
+      sleepNoteForm: createSleepNoteForm(),
+      symptomSuggestions: [
+        {
+          label: 'Headache',
+          code: 'R51',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+          sourceName: 'Clinical Tables Conditions',
+        },
+        { label: 'Headache disorder', code: 'R51.9', sourceName: 'Clinical Tables Conditions' },
+      ],
+      symptomSuggestionNotice: 'Suggestions from Clinical Tables Conditions.',
+      symptomSuggestionMetadata: {
+        provenance: [
+          {
+            sourceId: 'clinical-tables-conditions',
+            sourceName: 'Clinical Tables Conditions',
+            category: 'reference',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+      onSymptomFieldChange,
+      onAnxietyFieldChange: vi.fn(),
+      onSleepNoteFieldChange: vi.fn(),
+      onSaveSymptom: vi.fn(),
+      onSaveAnxiety: vi.fn(),
+      onSaveSleepNote: vi.fn(),
+      onSearchSymptomSuggestions: vi.fn(),
+      onApplySymptomSuggestion: (suggestion: HealthSymptomSuggestion) =>
+        onSymptomFieldChange('symptom', suggestion.label),
+    });
+
+    expect(screen.getByText(/Suggestions from Clinical Tables Conditions\./i)).toBeTruthy();
+    expect(screen.getByText(/Sources: Clinical Tables Conditions/i)).toBeTruthy();
+    expect(screen.getByText(/Cache: remote-live/i)).toBeTruthy();
+    expect(screen.getByText(/Status: none/i)).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Learn more about Headache' }).getAttribute('href')).toBe(
+      'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en'
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'Use symptom Headache' }));
+
+    expect(onSymptomFieldChange).toHaveBeenCalledWith('symptom', 'Headache');
+  });
+
+  it('does not render unsafe suggestion links', () => {
+    render(HealthManualLoggingSection, {
+      symptomForm: createSymptomForm(),
+      anxietyForm: createAnxietyForm(),
+      sleepNoteForm: createSleepNoteForm(),
+      symptomSuggestions: [
+        {
+          label: 'Headache',
+          code: 'R51',
+          referenceUrl: 'javascript:alert(1)',
+          sourceName: 'Clinical Tables Conditions',
+        },
+      ],
+      symptomSuggestionNotice: 'Suggestions from Clinical Tables Conditions.',
+      symptomSuggestionMetadata: null,
+      onSymptomFieldChange: vi.fn(),
+      onAnxietyFieldChange: vi.fn(),
+      onSleepNoteFieldChange: vi.fn(),
+      onSaveSymptom: vi.fn(),
+      onSaveAnxiety: vi.fn(),
+      onSaveSleepNote: vi.fn(),
+      onSearchSymptomSuggestions: vi.fn(),
+      onApplySymptomSuggestion: vi.fn(),
+    });
+
+    expect(screen.queryByRole('link', { name: 'Learn more about Headache' })).toBeNull();
+  });
+});

--- a/tests/features/component/health/HealthPage.medication-metadata.spec.ts
+++ b/tests/features/component/health/HealthPage.medication-metadata.spec.ts
@@ -10,10 +10,9 @@ describe('Health route medication suggestion metadata', () => {
 
   it('clears medication suggestion notice and metadata after applying a suggested medication', async () => {
     vi.doMock('$lib/features/health/client', async () => {
-      const actual =
-        await vi.importActual<typeof import('../../../../src/lib/features/health/client')>(
-          '$lib/features/health/client'
-        );
+      const actual = await vi.importActual<
+        typeof import('../../../../src/lib/features/health/client')
+      >('$lib/features/health/client');
 
       return {
         ...actual,
@@ -75,5 +74,4 @@ describe('Health route medication suggestion metadata', () => {
     expect(screen.queryByText('Server-owned medication guidance.')).toBeNull();
     expect(screen.queryByText(/Sources: RxNorm/i)).toBeNull();
   });
-
 });

--- a/tests/features/component/health/HealthPage.medication-metadata.spec.ts
+++ b/tests/features/component/health/HealthPage.medication-metadata.spec.ts
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('Health route medication suggestion metadata', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/features/health/client');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('clears medication suggestion notice and metadata after applying a suggested medication', async () => {
+    vi.doMock('$lib/features/health/client', async () => {
+      const actual =
+        await vi.importActual<typeof import('../../../../src/lib/features/health/client')>(
+          '$lib/features/health/client'
+        );
+
+      return {
+        ...actual,
+        loadHealthPage: vi.fn(async () => ({
+          ...actual.createHealthPageState(),
+          loading: false,
+          localDay: '2026-04-17',
+          snapshot: { sleepEvent: null, events: [], templates: [] },
+        })),
+        searchHealthMedicationSuggestions: vi.fn(async () => ({
+          suggestions: [
+            {
+              label: 'Metformin 500 MG Oral Tablet',
+              code: '860975',
+              sourceName: 'RxNorm',
+            },
+          ],
+          notice: 'Server-owned medication guidance.',
+          metadata: {
+            provenance: [
+              {
+                sourceId: 'rxnorm',
+                sourceName: 'RxNorm',
+                category: 'reference',
+                productionPosture: 'adopt',
+              },
+            ],
+            cacheStatus: 'remote-live',
+            degradationStatus: 'none',
+          },
+        })),
+        saveSymptomPage: vi.fn(),
+        saveAnxietyPage: vi.fn(),
+        saveSleepNotePage: vi.fn(),
+        saveTemplatePage: vi.fn(),
+        quickLogTemplatePage: vi.fn(),
+      };
+    });
+
+    const { default: HealthPage } = await import('../../../../src/routes/health/+page.svelte');
+    render(HealthPage);
+
+    await screen.findByLabelText('Template name');
+    await fireEvent.change(screen.getByLabelText('Template type'), {
+      target: { value: 'medication' },
+    });
+    await fireEvent.input(screen.getByLabelText('Template name'), {
+      target: { value: 'Metformin' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Suggest medications' }));
+
+    expect(await screen.findByText('Server-owned medication guidance.')).toBeTruthy();
+    expect(screen.getByText(/Sources: RxNorm/i)).toBeTruthy();
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Use medication Metformin 500 MG Oral Tablet' })
+    );
+
+    expect(screen.queryByText('Server-owned medication guidance.')).toBeNull();
+    expect(screen.queryByText(/Sources: RxNorm/i)).toBeNull();
+  });
+
+});

--- a/tests/features/component/health/HealthPage.spec.ts
+++ b/tests/features/component/health/HealthPage.spec.ts
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { getTestHealthDb } from '$lib/core/db/test-client';
 import HealthPage from '../../../../src/routes/health/+page.svelte';
 import { expectHeading, resetRouteDb } from '../../../support/component/routeHarness';
 
@@ -70,6 +71,33 @@ describe('Health route', () => {
         within(healthStream as HTMLElement).getByText('Sleep note', { exact: true })
       ).toBeTruthy();
       expect(within(healthStream as HTMLElement).getByText('Magnesium glycinate')).toBeTruthy();
+    });
+  });
+
+  it('surfaces a saved medication template reference link after quick logging it', async () => {
+    await getTestHealthDb().healthTemplates.put({
+      id: 'template-med-1',
+      createdAt: '2026-04-17T00:00:00.000Z',
+      updatedAt: '2026-04-17T00:00:00.000Z',
+      label: 'Metformin 500 MG Oral Tablet',
+      templateType: 'medication',
+      defaultDose: 1,
+      defaultUnit: 'tablet',
+      note: 'With breakfast',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+    });
+
+    render(HealthPage);
+
+    await waitFor(() => {
+      expect(screen.getByText('Metformin 500 MG Oral Tablet')).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Log now' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Learn more about logged medication Metformin 500 MG Oral Tablet' })).toBeTruthy();
     });
   });
 });

--- a/tests/features/component/health/HealthPage.spec.ts
+++ b/tests/features/component/health/HealthPage.spec.ts
@@ -97,7 +97,11 @@ describe('Health route', () => {
     await fireEvent.click(screen.getByRole('button', { name: 'Log now' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('link', { name: 'Learn more about logged medication Metformin 500 MG Oral Tablet' })).toBeTruthy();
+      expect(
+        screen.getByRole('link', {
+          name: 'Learn more about logged medication Metformin 500 MG Oral Tablet',
+        })
+      ).toBeTruthy();
     });
   });
 });

--- a/tests/features/component/health/HealthPage.suggestion-notice.spec.ts
+++ b/tests/features/component/health/HealthPage.suggestion-notice.spec.ts
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('Health route symptom suggestion notice', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/features/health/client');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('uses the notice returned by the health suggestion client instead of hardcoding it', async () => {
+    vi.doMock('$lib/features/health/client', async () => {
+      const actual =
+        await vi.importActual<typeof import('../../../../src/lib/features/health/client')>(
+          '$lib/features/health/client'
+        );
+
+      return {
+        ...actual,
+        loadHealthPage: vi.fn(async () => ({
+          ...actual.createHealthPageState(),
+          loading: false,
+          localDay: '2026-04-17',
+          snapshot: { sleepEvent: null, events: [], templates: [] },
+        })),
+        searchHealthSymptomSuggestions: vi.fn(async () => ({
+          suggestions: [
+            { label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' },
+          ],
+          notice: 'Server-owned symptom guidance.',
+          metadata: {
+            provenance: [],
+            cacheStatus: 'remote-live',
+            degradationStatus: 'none',
+          },
+        })),
+        saveSymptomPage: vi.fn(),
+        saveAnxietyPage: vi.fn(),
+        saveSleepNotePage: vi.fn(),
+        saveTemplatePage: vi.fn(),
+        quickLogTemplatePage: vi.fn(),
+      };
+    });
+
+    const { default: HealthPage } = await import('../../../../src/routes/health/+page.svelte');
+    render(HealthPage);
+
+    await screen.findByLabelText('Symptom');
+    await fireEvent.input(screen.getByLabelText('Symptom'), { target: { value: 'Head' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Suggest symptoms' }));
+
+    expect(await screen.findByText('Server-owned symptom guidance.')).toBeTruthy();
+  });
+});

--- a/tests/features/component/health/HealthPage.suggestion-notice.spec.ts
+++ b/tests/features/component/health/HealthPage.suggestion-notice.spec.ts
@@ -10,10 +10,9 @@ describe('Health route symptom suggestion notice', () => {
 
   it('uses the notice returned by the health suggestion client instead of hardcoding it', async () => {
     vi.doMock('$lib/features/health/client', async () => {
-      const actual =
-        await vi.importActual<typeof import('../../../../src/lib/features/health/client')>(
-          '$lib/features/health/client'
-        );
+      const actual = await vi.importActual<
+        typeof import('../../../../src/lib/features/health/client')
+      >('$lib/features/health/client');
 
       return {
         ...actual,

--- a/tests/features/component/health/HealthPage.symptom-metadata.spec.ts
+++ b/tests/features/component/health/HealthPage.symptom-metadata.spec.ts
@@ -10,10 +10,9 @@ describe('Health route symptom suggestion metadata', () => {
 
   it('clears symptom suggestion notice and metadata after logging the selected symptom', async () => {
     vi.doMock('$lib/features/health/client', async () => {
-      const actual =
-        await vi.importActual<typeof import('../../../../src/lib/features/health/client')>(
-          '$lib/features/health/client'
-        );
+      const actual = await vi.importActual<
+        typeof import('../../../../src/lib/features/health/client')
+      >('$lib/features/health/client');
       const saveSymptomPage = vi.fn(async (state) => ({
         ...state,
         loading: false,
@@ -72,5 +71,4 @@ describe('Health route symptom suggestion metadata', () => {
     expect(screen.queryByText('Server-owned symptom guidance.')).toBeNull();
     expect(screen.queryByText(/Sources: Clinical Tables Conditions/i)).toBeNull();
   });
-
 });

--- a/tests/features/component/health/HealthPage.symptom-metadata.spec.ts
+++ b/tests/features/component/health/HealthPage.symptom-metadata.spec.ts
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('Health route symptom suggestion metadata', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/features/health/client');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('clears symptom suggestion notice and metadata after logging the selected symptom', async () => {
+    vi.doMock('$lib/features/health/client', async () => {
+      const actual =
+        await vi.importActual<typeof import('../../../../src/lib/features/health/client')>(
+          '$lib/features/health/client'
+        );
+      const saveSymptomPage = vi.fn(async (state) => ({
+        ...state,
+        loading: false,
+        snapshot: { sleepEvent: null, events: [], templates: [] },
+        saveNotice: 'Symptom logged.',
+        symptomForm: actual.createHealthPageState().symptomForm,
+      }));
+
+      return {
+        ...actual,
+        loadHealthPage: vi.fn(async () => ({
+          ...actual.createHealthPageState(),
+          loading: false,
+          localDay: '2026-04-17',
+          snapshot: { sleepEvent: null, events: [], templates: [] },
+        })),
+        searchHealthSymptomSuggestions: vi.fn(async () => ({
+          suggestions: [
+            { label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' },
+          ],
+          notice: 'Server-owned symptom guidance.',
+          metadata: {
+            provenance: [
+              {
+                sourceId: 'clinical-tables-conditions',
+                sourceName: 'Clinical Tables Conditions',
+                category: 'reference',
+                productionPosture: 'adopt',
+              },
+            ],
+            cacheStatus: 'remote-live',
+            degradationStatus: 'none',
+          },
+        })),
+        saveSymptomPage,
+        saveAnxietyPage: vi.fn(),
+        saveSleepNotePage: vi.fn(),
+        saveTemplatePage: vi.fn(),
+        quickLogTemplatePage: vi.fn(),
+      };
+    });
+
+    const { default: HealthPage } = await import('../../../../src/routes/health/+page.svelte');
+    render(HealthPage);
+
+    await screen.findByLabelText('Symptom');
+    await fireEvent.input(screen.getByLabelText('Symptom'), { target: { value: 'Head' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Suggest symptoms' }));
+
+    expect(await screen.findByText('Server-owned symptom guidance.')).toBeTruthy();
+    expect(screen.getByText(/Sources: Clinical Tables Conditions/i)).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Use symptom Headache' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Log symptom' }));
+
+    expect(screen.queryByText('Server-owned symptom guidance.')).toBeNull();
+    expect(screen.queryByText(/Sources: Clinical Tables Conditions/i)).toBeNull();
+  });
+
+});

--- a/tests/features/component/health/HealthTemplateSection.spec.ts
+++ b/tests/features/component/health/HealthTemplateSection.spec.ts
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import HealthTemplateSection from '../../../../src/lib/features/health/components/HealthTemplateSection.svelte';
+import { createTemplateForm, type HealthMedicationSuggestion } from '$lib/features/health/model';
+
+describe('HealthTemplateSection', () => {
+  it('renders medication suggestions and applies a selected suggestion to the template name', async () => {
+    const onTemplateFieldChange = vi.fn();
+
+    render(HealthTemplateSection, {
+      templateForm: {
+        ...createTemplateForm(),
+        templateType: 'medication',
+      },
+      templates: [],
+      medicationSuggestions: [
+        {
+          label: 'Metformin 500 MG Oral Tablet',
+          code: '860975',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+          sourceName: 'RxNorm',
+        },
+      ],
+      medicationSuggestionNotice: 'Suggestions from RxNorm.',
+      medicationSuggestionMetadata: {
+        provenance: [
+          {
+            sourceId: 'rxnorm',
+            sourceName: 'RxNorm',
+            category: 'reference',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+      onTemplateFieldChange,
+      onSaveTemplate: vi.fn(),
+      onQuickLogTemplate: vi.fn(),
+      onSearchMedicationSuggestions: vi.fn(),
+      onApplyMedicationSuggestion: (suggestion: HealthMedicationSuggestion) =>
+        onTemplateFieldChange('label', suggestion),
+    });
+
+    expect(screen.getByText(/Suggestions from RxNorm\./i)).toBeTruthy();
+    expect(screen.getByText(/Sources: RxNorm/i)).toBeTruthy();
+    expect(screen.getByText(/Cache: remote-live/i)).toBeTruthy();
+    expect(screen.getByText(/Status: none/i)).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Learn more about Metformin 500 MG Oral Tablet' })).toBeTruthy();
+    await fireEvent.click(screen.getByRole('button', { name: 'Use medication Metformin 500 MG Oral Tablet' }));
+
+    expect(onTemplateFieldChange).toHaveBeenCalledWith(
+      'label',
+      expect.objectContaining({
+        label: 'Metformin 500 MG Oral Tablet',
+        referenceUrl:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+      })
+    );
+  });
+
+  it('renders a saved medication template reference link when one exists', () => {
+    render(HealthTemplateSection, {
+      templateForm: {
+        ...createTemplateForm(),
+        templateType: 'medication',
+      },
+      templates: [
+        {
+          id: 'template-1',
+          createdAt: '2026-04-17T00:00:00.000Z',
+          updatedAt: '2026-04-17T00:00:00.000Z',
+          label: 'Metformin 500 MG Oral Tablet',
+          templateType: 'medication',
+          defaultDose: 1,
+          defaultUnit: 'tablet',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+        },
+      ],
+      medicationSuggestions: [],
+      medicationSuggestionNotice: '',
+      medicationSuggestionMetadata: null,
+      onTemplateFieldChange: vi.fn(),
+      onSaveTemplate: vi.fn(),
+      onQuickLogTemplate: vi.fn(),
+      onSearchMedicationSuggestions: vi.fn(),
+      onApplyMedicationSuggestion: vi.fn(),
+    });
+
+    expect(screen.getByRole('link', { name: 'Learn more about saved medication Metformin 500 MG Oral Tablet' })).toBeTruthy();
+  });
+
+  it('renders a saved supplement template reference link without mislabeling it as medication', () => {
+    render(HealthTemplateSection, {
+      templateForm: {
+        ...createTemplateForm(),
+        templateType: 'supplement',
+      },
+      templates: [
+        {
+          id: 'template-2',
+          createdAt: '2026-04-17T00:00:00.000Z',
+          updatedAt: '2026-04-17T00:00:00.000Z',
+          label: 'Vitamin D3',
+          templateType: 'supplement',
+          defaultDose: 1,
+          defaultUnit: 'softgel',
+          referenceUrl: 'https://example.com/vitamin-d3',
+        },
+      ],
+      medicationSuggestions: [],
+      medicationSuggestionNotice: '',
+      medicationSuggestionMetadata: null,
+      onTemplateFieldChange: vi.fn(),
+      onSaveTemplate: vi.fn(),
+      onQuickLogTemplate: vi.fn(),
+      onSearchMedicationSuggestions: vi.fn(),
+      onApplyMedicationSuggestion: vi.fn(),
+    });
+
+    expect(
+      screen.getByRole('link', { name: 'Learn more about saved supplement Vitamin D3' })
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole('link', { name: 'Learn more about saved medication Vitamin D3' })
+    ).toBeNull();
+  });
+
+  it('does not render unsafe medication suggestion or saved-template links', () => {
+    render(HealthTemplateSection, {
+      templateForm: {
+        ...createTemplateForm(),
+        templateType: 'medication',
+      },
+      templates: [
+        {
+          id: 'template-3',
+          createdAt: '2026-04-17T00:00:00.000Z',
+          updatedAt: '2026-04-17T00:00:00.000Z',
+          label: 'Unsafe Supplement',
+          templateType: 'supplement',
+          referenceUrl: 'javascript:alert(1)',
+        },
+      ],
+      medicationSuggestions: [
+        {
+          label: 'Unsafe Med',
+          code: '1',
+          referenceUrl: 'javascript:alert(1)',
+          sourceName: 'RxNorm',
+        },
+      ],
+      medicationSuggestionNotice: 'Suggestions from RxNorm.',
+      medicationSuggestionMetadata: null,
+      onTemplateFieldChange: vi.fn(),
+      onSaveTemplate: vi.fn(),
+      onQuickLogTemplate: vi.fn(),
+      onSearchMedicationSuggestions: vi.fn(),
+      onApplyMedicationSuggestion: vi.fn(),
+    });
+
+    expect(screen.queryByRole('link', { name: 'Learn more about Unsafe Med' })).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: 'Learn more about saved supplement Unsafe Supplement' })
+    ).toBeNull();
+  });
+});

--- a/tests/features/component/health/HealthTemplateSection.spec.ts
+++ b/tests/features/component/health/HealthTemplateSection.spec.ts
@@ -47,8 +47,12 @@ describe('HealthTemplateSection', () => {
     expect(screen.getByText(/Sources: RxNorm/i)).toBeTruthy();
     expect(screen.getByText(/Cache: remote-live/i)).toBeTruthy();
     expect(screen.getByText(/Status: none/i)).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Learn more about Metformin 500 MG Oral Tablet' })).toBeTruthy();
-    await fireEvent.click(screen.getByRole('button', { name: 'Use medication Metformin 500 MG Oral Tablet' }));
+    expect(
+      screen.getByRole('link', { name: 'Learn more about Metformin 500 MG Oral Tablet' })
+    ).toBeTruthy();
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Use medication Metformin 500 MG Oral Tablet' })
+    );
 
     expect(onTemplateFieldChange).toHaveBeenCalledWith(
       'label',
@@ -89,7 +93,11 @@ describe('HealthTemplateSection', () => {
       onApplyMedicationSuggestion: vi.fn(),
     });
 
-    expect(screen.getByRole('link', { name: 'Learn more about saved medication Metformin 500 MG Oral Tablet' })).toBeTruthy();
+    expect(
+      screen.getByRole('link', {
+        name: 'Learn more about saved medication Metformin 500 MG Oral Tablet',
+      })
+    ).toBeTruthy();
   });
 
   it('renders a saved supplement template reference link without mislabeling it as medication', () => {

--- a/tests/features/component/imports/ImportsPage.base.spec.ts
+++ b/tests/features/component/imports/ImportsPage.base.spec.ts
@@ -24,7 +24,7 @@ describe('Imports route base flows', () => {
     expect(screen.getByRole('heading', { name: 'Imports' })).toBeTruthy();
     await waitFor(() => {
       expect(getImportSourceSelect()).toBeTruthy();
-      expect(screen.getByRole('option', { name: 'iPhone bundle / Shortcuts JSON' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'iPhone HealthKit Companion' })).toBeTruthy();
       expect(screen.getByRole('option', { name: 'SMART sandbox FHIR JSON' })).toBeTruthy();
       expect(screen.getByText(/Apple Shortcuts/i)).toBeTruthy();
       expect(
@@ -47,13 +47,21 @@ describe('Imports route base flows', () => {
     await fireEvent.click(getPreviewButton());
 
     await waitFor(() => {
-      expect(screen.getByText(/Adds: 1/i)).toBeTruthy();
+      const previewSummary = screen.getByLabelText('Import payload summary');
+      expect(previewSummary.textContent).toContain('1');
     });
 
     await fireEvent.click(getCommitButton());
     await waitFor(() => {
       expect(screen.getByRole('status')).toBeTruthy();
       expect(screen.getByText(/day-one-json/i)).toBeTruthy();
+      const historySection = screen
+        .getByRole('heading', { name: 'Import batch history' })
+        .closest('section') as HTMLElement;
+      expect(historySection.textContent).toContain('Adds: 1');
+      expect(historySection.textContent).toContain('Duplicates: 0');
+      expect(historySection.textContent).toContain('Warnings: 0');
+      expect(historySection.textContent).toContain('Updated:');
     });
   });
 
@@ -65,7 +73,8 @@ describe('Imports route base flows', () => {
     await pasteImportPayload(APPLE_HEALTH_XML);
     await fireEvent.click(getPreviewButton());
     await waitFor(() => {
-      expect(screen.getByText(/Adds: 1/i)).toBeTruthy();
+      const previewSummary = screen.getByLabelText('Import payload summary');
+      expect(previewSummary.textContent).toContain('1');
     });
     await fireEvent.click(getCommitButton());
     await waitFor(() => {
@@ -75,7 +84,11 @@ describe('Imports route base flows', () => {
     await fireEvent.click(getPreviewButton());
     await waitFor(() => {
       expect(screen.getAllByText(/apple-health-xml/i).length).toBeGreaterThan(0);
-      expect(screen.getByText(/Duplicates: 1/i)).toBeTruthy();
+      expect(screen.getAllByText(/Duplicates: 1/i).length).toBeGreaterThan(0);
+      const historySection = screen
+        .getByRole('heading', { name: 'Import batch history' })
+        .closest('section') as HTMLElement;
+      expect(historySection.textContent).toContain('Updated:');
     });
   });
 });

--- a/tests/features/component/imports/ImportsPage.healthkit.spec.ts
+++ b/tests/features/component/imports/ImportsPage.healthkit.spec.ts
@@ -151,7 +151,7 @@ describe('Imports route healthkit flows', () => {
     await pasteImportPayload(`${HEALTHKIT_BUNDLE_JSON}\n`);
 
     await waitFor(() => {
-      expect(screen.getAllByText(/Adds: 3/i).length).toBe(1);
+      expect(screen.queryByText(/Adds: 3/i)).toBeNull();
       expect(getCommitButton()).toHaveProperty('disabled', true);
       expect(screen.getByLabelText('Import payload summary')).toBeTruthy();
     });

--- a/tests/features/component/imports/ImportsPage.healthkit.spec.ts
+++ b/tests/features/component/imports/ImportsPage.healthkit.spec.ts
@@ -33,12 +33,32 @@ describe('Imports route healthkit flows', () => {
     await fireEvent.click(getPreviewButton());
 
     await waitFor(() => {
-      expect(screen.getByText(/Adds: 3/i)).toBeTruthy();
+      const previewSummary = screen.getByLabelText('Import payload summary');
+      expect(previewSummary.textContent).toContain('3');
     });
 
     await fireEvent.click(getCommitButton());
     await waitFor(() => {
       expect(screen.getByText(/healthkit-companion/i)).toBeTruthy();
+      const historySection = screen
+        .getByRole('heading', { name: 'Import batch history' })
+        .closest('section') as HTMLElement;
+      expect(historySection.textContent).toContain('Adds: 3');
+      expect(historySection.textContent).toContain('Duplicates: 0');
+      expect(historySection.textContent).toContain('Warnings: 0');
+      expect(historySection.textContent).toContain('Updated:');
+    });
+  });
+
+  it('shows registry-backed trust and auth context for the HealthKit import lane', async () => {
+    renderImportsPage();
+
+    await screen.findByLabelText('Import source');
+    await selectImportSource('healthkit-companion');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Trust: official/i)).toBeTruthy();
+      expect(screen.getByText(/Auth: native-consent/i)).toBeTruthy();
     });
   });
 
@@ -51,7 +71,7 @@ describe('Imports route healthkit flows', () => {
     expect(getPreviewButton()).toHaveProperty('disabled', true);
 
     const summary = await waitForCompanionSummary();
-    expect(summary.getByText(/Detected source: iPhone bundle \/ Shortcuts JSON/i)).toBeTruthy();
+    expect(summary.getByText(/Detected source: iPhone HealthKit Companion/i)).toBeTruthy();
   });
 
   it('loads a bundle from a file input and infers the source type', async () => {
@@ -124,14 +144,14 @@ describe('Imports route healthkit flows', () => {
     await fireEvent.click(getPreviewButton());
 
     await waitFor(() => {
-      expect(screen.getByText(/Adds: 3/i)).toBeTruthy();
+      expect(screen.getAllByText(/Adds: 3/i).length).toBeGreaterThan(0);
       expect(getCommitButton()).toHaveProperty('disabled', false);
     });
 
     await pasteImportPayload(`${HEALTHKIT_BUNDLE_JSON}\n`);
 
     await waitFor(() => {
-      expect(screen.queryByText(/Adds: 3/i)).toBeNull();
+      expect(screen.getAllByText(/Adds: 3/i).length).toBe(1);
       expect(getCommitButton()).toHaveProperty('disabled', true);
       expect(screen.getByLabelText('Import payload summary')).toBeTruthy();
     });

--- a/tests/features/component/imports/ImportsPage.smart.spec.ts
+++ b/tests/features/component/imports/ImportsPage.smart.spec.ts
@@ -52,12 +52,25 @@ describe('Imports route SMART clinical flows', () => {
     await fireEvent.click(getPreviewButton());
 
     await waitFor(() => {
-      expect(screen.getByText(/Adds: 3/i)).toBeTruthy();
+      const previewSummary = screen.getByLabelText('Import payload summary');
+      expect(previewSummary.textContent).toContain('3');
     });
 
     await fireEvent.click(getCommitButton());
     await waitFor(() => {
       expect(screen.getByText(/smart-fhir-sandbox/i)).toBeTruthy();
+    });
+  });
+
+  it('shows registry-backed trust and auth context for the SMART sandbox lane', async () => {
+    renderImportsPage();
+
+    await screen.findByLabelText('Import source');
+    await selectImportSource('smart-fhir-sandbox');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Trust: sandbox/i)).toBeTruthy();
+      expect(screen.getByText(/Auth: oauth2/i)).toBeTruthy();
     });
   });
 });

--- a/tests/features/component/integrations/IntegrationsPage.spec.ts
+++ b/tests/features/component/integrations/IntegrationsPage.spec.ts
@@ -37,11 +37,14 @@ describe('Integrations route', () => {
 
   it('shows a connected summary after a native companion bundle is committed', async () => {
     const db = getTestHealthDb();
-    const batch = await previewImport(db, {
+    await previewImport(db, {
       sourceType: 'healthkit-companion',
       rawText: HEALTHKIT_BUNDLE_JSON,
     });
-    await commitImportBatch(db, batch.id);
+    await commitImportBatch(db, {
+      sourceType: 'healthkit-companion',
+      rawText: HEALTHKIT_BUNDLE_JSON,
+    });
 
     render(IntegrationsPage);
 

--- a/tests/features/component/nutrition/NutritionComposerSection.spec.ts
+++ b/tests/features/component/nutrition/NutritionComposerSection.spec.ts
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import NutritionComposerSection from '../../../../src/lib/features/nutrition/components/NutritionComposerSection.svelte';
+import { createNutritionForm } from '../../../../src/lib/features/nutrition/model';
+
+describe('NutritionComposerSection', () => {
+  it('renders USDA and Open Food Facts metadata when search responses carry source metadata', () => {
+    render(NutritionComposerSection, {
+      searchQuery: 'oatmeal',
+      searchNotice: 'USDA live search unavailable, using local fallback foods.',
+      searchMetadata: {
+        provenance: [
+          {
+            sourceId: 'usda-fooddata-central',
+            sourceName: 'USDA FoodData Central',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
+      },
+      matches: [],
+      packagedQuery: 'cola',
+      barcodeQuery: '',
+      packagedNotice: 'Open Food Facts search unavailable, using local packaged foods.',
+      packagedMetadata: {
+        provenance: [
+          {
+            sourceId: 'open-food-facts',
+            sourceName: 'Open Food Facts',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
+      },
+      packagedMatches: [],
+      recipeQuery: '',
+      recipeNotice: '',
+      recipeMatches: [],
+      form: createNutritionForm(),
+      saveNotice: '',
+      onSearchQueryChange: vi.fn(),
+      onSearchFoods: vi.fn(),
+      onUseMatch: vi.fn(),
+      onPackagedQueryChange: vi.fn(),
+      onSearchPackagedFoods: vi.fn(),
+      onBarcodeQueryChange: vi.fn(),
+      onLookupBarcode: vi.fn(),
+      onRecipeQueryChange: vi.fn(),
+      onSearchRecipes: vi.fn(),
+      onUseRecipe: vi.fn(),
+      onFormFieldChange: vi.fn(),
+      onSaveMeal: vi.fn(),
+      onPlanNextMeal: vi.fn(),
+      onSaveCustomFood: vi.fn(),
+      onSaveRecurringMeal: vi.fn(),
+    });
+
+    expect(screen.getByText(/Sources: USDA FoodData Central/i)).toBeTruthy();
+    expect(screen.getByText(/Sources: Open Food Facts/i)).toBeTruthy();
+    expect(screen.getAllByText(/local-cache/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/degraded/i).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/features/component/nutrition/NutritionPage.spec.ts
+++ b/tests/features/component/nutrition/NutritionPage.spec.ts
@@ -176,8 +176,8 @@ describe('Nutrition route', () => {
       const mealLoggingSection = Array.from(document.querySelectorAll('section')).find((section) =>
         section.textContent?.includes('Meal logging')
       );
-      const customCatalogSection = Array.from(document.querySelectorAll('section')).find((section) =>
-        section.textContent?.includes('Custom food catalog')
+      const customCatalogSection = Array.from(document.querySelectorAll('section')).find(
+        (section) => section.textContent?.includes('Custom food catalog')
       );
       expect(mealLoggingSection?.textContent).not.toContain('Teriyaki Chicken Casserole');
       expect(customCatalogSection?.textContent).toContain('Teriyaki Chicken Casserole');

--- a/tests/features/component/nutrition/NutritionPage.spec.ts
+++ b/tests/features/component/nutrition/NutritionPage.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { getTestHealthDb, resetTestHealthDb } from '$lib/core/db/test-client';
 import { currentLocalDay } from '$lib/core/domain/time';
@@ -153,7 +153,7 @@ describe('Nutrition route', () => {
     });
   });
 
-  it('does not fabricate zero macros when an unknown-macro custom food is searched and reused', async () => {
+  it('does not surface unknown-macro custom foods in USDA-backed search results', async () => {
     const db = getTestHealthDb();
     await db.foodCatalogItems.put({
       id: 'food-catalog-1',
@@ -176,22 +176,14 @@ describe('Nutrition route', () => {
       const mealLoggingSection = Array.from(document.querySelectorAll('section')).find((section) =>
         section.textContent?.includes('Meal logging')
       );
-      expect(mealLoggingSection?.textContent).toContain('Teriyaki Chicken Casserole');
-      expect(mealLoggingSection?.textContent).toContain('Nutrition totals unknown.');
-      expect(mealLoggingSection?.textContent).not.toContain('0 kcal');
-      expect(mealLoggingSection?.textContent).not.toContain('0g protein');
-    });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Use match' }));
-    await waitFor(() => {
-      expect((screen.getByLabelText('Meal name') as HTMLInputElement).value).toBe(
-        'Teriyaki Chicken Casserole'
+      const customCatalogSection = Array.from(document.querySelectorAll('section')).find((section) =>
+        section.textContent?.includes('Custom food catalog')
       );
-      expect((screen.getByLabelText('Calories') as HTMLInputElement).value).toBe('');
-      expect((screen.getByLabelText('Protein') as HTMLInputElement).value).toBe('');
-      expect((screen.getByLabelText('Fiber') as HTMLInputElement).value).toBe('');
-      expect((screen.getByLabelText('Carbs') as HTMLInputElement).value).toBe('');
-      expect((screen.getByLabelText('Fat') as HTMLInputElement).value).toBe('');
+      expect(mealLoggingSection?.textContent).not.toContain('Teriyaki Chicken Casserole');
+      expect(customCatalogSection?.textContent).toContain('Teriyaki Chicken Casserole');
+      expect(customCatalogSection?.textContent).toContain('Nutrition totals unknown.');
+      expect(customCatalogSection?.textContent).not.toContain('0 kcal');
+      expect(customCatalogSection?.textContent).not.toContain('0g protein');
     });
   });
 
@@ -258,6 +250,12 @@ describe('Nutrition route', () => {
     render(NutritionPage);
 
     await screen.findByText('Recommended next');
+    await waitFor(() => {
+      const recommendationSection = Array.from(document.querySelectorAll('section')).find(
+        (section) => section.textContent?.includes('Recommended next')
+      );
+      expect(recommendationSection?.textContent).toContain('310 kcal · 24g protein · 6g fiber');
+    });
     await fireEvent.click(screen.getByRole('button', { name: 'Load food' }));
 
     await waitFor(() => {
@@ -301,7 +299,7 @@ describe('Nutrition route', () => {
     expect(await db.foodCatalogItems.count()).toBe(1);
   });
 
-  it('plans a recommended recipe as a recipe slot without cloning it into the local food catalog', async () => {
+  it('does not offer direct planning for an optional-source recipe recommendation', async () => {
     const db = getTestHealthDb();
     await db.recipeCatalogItems.put({
       id: 'recipe-1',
@@ -319,28 +317,20 @@ describe('Nutrition route', () => {
     render(NutritionPage);
 
     await screen.findByText('Recommended next');
-    await fireEvent.click(screen.getByRole('button', { name: 'Plan next' }));
-
     await waitFor(() => {
-      expect(screen.getByText(/Planned next meal saved\./i)).toBeTruthy();
-      expect(screen.getAllByText('Teriyaki Chicken Bowl').length).toBeGreaterThan(0);
+      const recommendationSection = Array.from(document.querySelectorAll('section')).find(
+        (section) => section.textContent?.includes('Recommended next')
+      );
+      expect(recommendationSection?.textContent).toContain('Source: TheMealDB');
+      expect(recommendationSection?.textContent).toContain('Posture: optional');
+      expect(
+        within(recommendationSection as HTMLElement).queryByRole('button', { name: 'Plan next' })
+      ).toBeNull();
+      expect(
+        within(recommendationSection as HTMLElement).getByRole('button', { name: 'Review first' })
+      ).toBeTruthy();
     });
-
-    const planSlots = await db.planSlots.toArray();
-    expect(planSlots).toHaveLength(1);
-    expect(planSlots[0]).toEqual(
-      expect.objectContaining({
-        itemType: 'recipe',
-        itemId: 'recipe-1',
-        mealType: 'dinner',
-        title: 'Teriyaki Chicken Bowl',
-      })
-    );
-    expect(
-      (await db.foodCatalogItems.toArray()).find(
-        (item) => item.name === 'Teriyaki Chicken Bowl' && item.sourceName === 'Local catalog'
-      )
-    ).toBeUndefined();
+    expect(await db.planSlots.count()).toBe(0);
   });
 
   it('keeps recommendation copy truthful for saved foods whose nutrition totals are still unknown', async () => {

--- a/tests/features/component/review/ReviewPage.spec.ts
+++ b/tests/features/component/review/ReviewPage.spec.ts
@@ -510,15 +510,13 @@ describe('Review route', () => {
           healthReferenceLinks: [
             {
               label: 'Metformin 500 MG Oral Tablet',
-              href:
-                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+              href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
             },
           ],
           symptomReferenceLinks: [
             {
               label: 'Headache',
-              href:
-                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+              href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
             },
           ],
         })
@@ -560,15 +558,13 @@ describe('Review route', () => {
           healthReferenceLinks: [
             {
               label: 'Metformin 500 MG Oral Tablet',
-              href:
-                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+              href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
             },
           ],
           symptomReferenceLinks: [
             {
               label: 'Headache',
-              href:
-                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+              href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
             },
           ],
         })

--- a/tests/features/component/review/ReviewPage.spec.ts
+++ b/tests/features/component/review/ReviewPage.spec.ts
@@ -196,6 +196,8 @@ function buildWeeklyData(
     grocerySignals: [],
     deviceHighlights: ['Sleep duration: 8 hours on 2026-04-02'],
     assessmentSummary: ['WHO-5: Strong wellbeing (17)'],
+    healthReferenceLinks: [],
+    symptomReferenceLinks: [],
     healthHighlights: ['Low sleep lined up with higher anxiety on 2026-03-31.'],
     contextSignals: ['Low sleep and a written reflection both landed on 2026-03-31.'],
     contextCaptureLinkedEventIds: ['anxiety-1'],
@@ -498,6 +500,117 @@ describe('Review route', () => {
       within(headlineSection).queryByText(
         /^Low sleep lined up with higher anxiety on 2026-03-31\.$/i
       )
+    ).toBeNull();
+  });
+
+  it('renders medication and symptom reference links in a unified review section', async () => {
+    reviewClientMock.setLoadState(
+      buildReviewState(
+        buildWeeklyData({
+          healthReferenceLinks: [
+            {
+              label: 'Metformin 500 MG Oral Tablet',
+              href:
+                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+            },
+          ],
+          symptomReferenceLinks: [
+            {
+              label: 'Headache',
+              href:
+                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+            },
+          ],
+        })
+      )
+    );
+
+    render(ReviewPage);
+
+    const referencesSection = await waitFor(() => getSection('Health references'));
+    expect(within(referencesSection).getByText('Medication')).toBeTruthy();
+    expect(within(referencesSection).getByText('Symptom')).toBeTruthy();
+    expect(within(referencesSection).getByText('Medication').className).toMatch(
+      /reference-pill--medication/
+    );
+    expect(within(referencesSection).getByText('Symptom').className).toMatch(
+      /reference-pill--symptom/
+    );
+    const medicationLink = within(referencesSection).getByRole('link', {
+      name: 'Medication reference Metformin 500 MG Oral Tablet opens in new tab',
+    });
+    const symptomLink = within(referencesSection).getByRole('link', {
+      name: 'Symptom reference Headache opens in new tab',
+    });
+
+    expect(medicationLink.getAttribute('href')).toBe(
+      'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en'
+    );
+    expect(medicationLink.getAttribute('target')).toBe('_blank');
+    expect(symptomLink.getAttribute('href')).toBe(
+      'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en'
+    );
+    expect(symptomLink.getAttribute('target')).toBe('_blank');
+  });
+
+  it('adds category-aware accessible names to health reference links', async () => {
+    reviewClientMock.setLoadState(
+      buildReviewState(
+        buildWeeklyData({
+          healthReferenceLinks: [
+            {
+              label: 'Metformin 500 MG Oral Tablet',
+              href:
+                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+            },
+          ],
+          symptomReferenceLinks: [
+            {
+              label: 'Headache',
+              href:
+                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+            },
+          ],
+        })
+      )
+    );
+
+    render(ReviewPage);
+
+    const referencesSection = await waitFor(() => getSection('Health references'));
+    expect(
+      within(referencesSection).getByRole('link', {
+        name: 'Medication reference Metformin 500 MG Oral Tablet opens in new tab',
+      })
+    ).toBeTruthy();
+    expect(
+      within(referencesSection).getByRole('link', {
+        name: 'Symptom reference Headache opens in new tab',
+      })
+    ).toBeTruthy();
+  });
+
+  it('does not render unsafe health reference links', async () => {
+    reviewClientMock.setLoadState(
+      buildReviewState(
+        buildWeeklyData({
+          healthReferenceLinks: [
+            {
+              label: 'Unsafe medication',
+              href: 'javascript:alert(1)',
+            },
+          ],
+        })
+      )
+    );
+
+    render(ReviewPage);
+
+    const referencesSection = await waitFor(() => getSection('Health references'));
+    expect(
+      within(referencesSection).queryByRole('link', {
+        name: 'Medication reference Unsafe medication opens in new tab',
+      })
     ).toBeNull();
   });
 });

--- a/tests/features/component/timeline/TimelinePage.spec.ts
+++ b/tests/features/component/timeline/TimelinePage.spec.ts
@@ -49,6 +49,8 @@ describe('Timeline route', () => {
     await waitFor(() => {
       expect(screen.getByText(/Symptom/i)).toBeTruthy();
     });
-    expect(screen.queryByRole('link', { name: 'Learn more about timeline event Symptom' })).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: 'Learn more about timeline event Symptom' })
+    ).toBeNull();
   });
 });

--- a/tests/features/component/timeline/TimelinePage.spec.ts
+++ b/tests/features/component/timeline/TimelinePage.spec.ts
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { getTestHealthDb } from '$lib/core/db/test-client';
 import TimelinePage from '../../../../src/routes/timeline/+page.svelte';
 import { expectHeading, resetRouteDb } from '../../../support/component/routeHarness';
 import { seedHealthkitImport } from '../../../support/component/routeSeeds';
@@ -20,5 +21,34 @@ describe('Timeline route', () => {
       expect(screen.getAllByText(/HealthKit Companion · Pyro iPhone/i)).toHaveLength(3);
       expect(screen.getByText(/57 bpm/i)).toBeTruthy();
     });
+  });
+
+  it('does not render unsafe timeline reference links', async () => {
+    const db = getTestHealthDb();
+    await db.healthEvents.put({
+      id: 'timeline-unsafe-link',
+      createdAt: '2026-04-17T09:10:00Z',
+      updatedAt: '2026-04-17T09:10:00Z',
+      sourceType: 'manual',
+      sourceApp: 'Personal Health Cockpit',
+      localDay: '2026-04-17',
+      confidence: 1,
+      eventType: 'symptom',
+      value: 4,
+      payload: {
+        kind: 'symptom',
+        symptom: 'Headache',
+        severity: 4,
+        referenceUrl: 'javascript:alert(1)',
+      },
+    });
+
+    render(TimelinePage);
+    expectHeading('Timeline');
+
+    await waitFor(() => {
+      expect(screen.getByText(/Symptom/i)).toBeTruthy();
+    });
+    expect(screen.queryByRole('link', { name: 'Learn more about timeline event Symptom' })).toBeNull();
   });
 });

--- a/tests/features/component/today/TodayPage.spec.ts
+++ b/tests/features/component/today/TodayPage.spec.ts
@@ -158,7 +158,9 @@ describe('Today route', () => {
     await waitFor(() => {
       expect(screen.getByText('Symptom')).toBeTruthy();
     });
-    expect(screen.queryByRole('link', { name: 'Learn more about same-day event Symptom' })).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: 'Learn more about same-day event Symptom' })
+    ).toBeNull();
   });
 
   it('shows a planned meal and lets today log it immediately', async () => {

--- a/tests/features/component/today/TodayPage.spec.ts
+++ b/tests/features/component/today/TodayPage.spec.ts
@@ -95,6 +95,72 @@ describe('Today route', () => {
     });
   });
 
+  it('renders learn-more links for same-day events that carry a reference url', async () => {
+    const db = getTestHealthDb();
+    const localDay = currentLocalDay();
+    await db.healthEvents.bulkAdd([
+      {
+        id: `manual-symptom-${localDay}`,
+        createdAt: '2026-04-02T09:10:00Z',
+        updatedAt: '2026-04-02T09:10:00Z',
+        sourceType: 'manual',
+        sourceApp: 'Personal Health Cockpit',
+        localDay,
+        confidence: 1,
+        eventType: 'symptom',
+        value: 4,
+        payload: {
+          kind: 'symptom',
+          symptom: 'Headache',
+          severity: 4,
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+        },
+      },
+    ]);
+
+    render(TodayPage);
+    expectHeading('Today');
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Learn more about same-day event Symptom' })
+      ).toBeTruthy();
+    });
+  });
+
+  it('does not render unsafe learn-more links for same-day events', async () => {
+    const db = getTestHealthDb();
+    const localDay = currentLocalDay();
+    await db.healthEvents.bulkAdd([
+      {
+        id: `manual-symptom-unsafe-${localDay}`,
+        createdAt: '2026-04-02T09:10:00Z',
+        updatedAt: '2026-04-02T09:10:00Z',
+        sourceType: 'manual',
+        sourceApp: 'Personal Health Cockpit',
+        localDay,
+        confidence: 1,
+        eventType: 'symptom',
+        value: 4,
+        payload: {
+          kind: 'symptom',
+          symptom: 'Headache',
+          severity: 4,
+          referenceUrl: 'javascript:alert(1)',
+        },
+      },
+    ]);
+
+    render(TodayPage);
+    expectHeading('Today');
+
+    await waitFor(() => {
+      expect(screen.getByText('Symptom')).toBeTruthy();
+    });
+    expect(screen.queryByRole('link', { name: 'Learn more about same-day event Symptom' })).toBeNull();
+  });
+
   it('shows a planned meal and lets today log it immediately', async () => {
     const db = getTestHealthDb();
     const localDay = currentLocalDay();

--- a/tests/features/component/today/TodayRecommendationSection.spec.ts
+++ b/tests/features/component/today/TodayRecommendationSection.spec.ts
@@ -117,4 +117,34 @@ describe('TodayRecommendationSection', () => {
       label: 'Capture context',
     });
   });
+
+  it('renders source-kind badges for recommendation provenance rows', () => {
+    render(TodayRecommendationSection, {
+      snapshot: createSnapshot({
+        intelligence: {
+          primaryRecommendation: {
+            ...createSnapshot().intelligence.primaryRecommendation!,
+            provenance: [
+              {
+                label: 'Sleep hours: 5.5, daily check-in',
+                sourceKind: 'daily_record',
+                sourceId: 'daily:2026-04-14',
+              },
+              {
+                label: 'Symptom: 4, manual',
+                sourceKind: 'health_event',
+                sourceId: 'symptom-1',
+              },
+            ],
+          },
+          fallbackState: null,
+        },
+      }),
+      recommendationSupportRows: [],
+      onRecommendationAction: vi.fn(),
+    });
+
+    expect(screen.getByText('Daily record')).toBeTruthy();
+    expect(screen.getByText('Health event')).toBeTruthy();
+  });
 });

--- a/tests/features/e2e/imports.e2e.ts
+++ b/tests/features/e2e/imports.e2e.ts
@@ -32,6 +32,33 @@ test('imports flow with preview and commit', async ({ page }) => {
   await expect(page.getByRole('status')).toBeVisible();
 });
 
+test('day one replay preview reports duplicates after the same entry was already committed', async ({
+  page,
+}) => {
+  const importsPage = new ImportsPage(page);
+  const payload = JSON.stringify({
+    entries: [
+      {
+        uuid: 'entry-1',
+        creationDate: '2026-04-02T09:00:00Z',
+        text: 'Morning reflection from Day One.',
+      },
+    ],
+  });
+
+  await importsPage.goto();
+  await importsPage.selectSource('day-one-json');
+  await importsPage.fillPayload(payload);
+  await importsPage.previewAndExpectAdds(1);
+  await importsPage.commit();
+  await importsPage.expectCommitted();
+
+  await importsPage.fillPayload(payload);
+  await importsPage.preview();
+  await expect(importsPage.previewSummary).toContainText('Adds: 0');
+  await expect(importsPage.previewSummary).toContainText('Duplicates: 1');
+});
+
 test('smart sandbox import requires an owner profile and lands in timeline once configured', async ({
   page,
 }) => {
@@ -162,7 +189,7 @@ test('editing a pasted payload clears stale preview state', async ({ page }) => 
   await expect(importsPage.commitButton).toBeEnabled();
 
   await importsPage.payloadInput.fill(`${HEALTHKIT_BUNDLE_JSON}\n`);
-  await expect(page.getByText(/Adds: 3/i)).toHaveCount(0);
+  await expect(importsPage.previewSummary).toHaveCount(0);
   await expect(importsPage.commitButton).toBeDisabled();
 });
 

--- a/tests/features/e2e/today-handoffs.e2e.ts
+++ b/tests/features/e2e/today-handoffs.e2e.ts
@@ -351,7 +351,7 @@ test('today can clear a planned meal handoff after nutrition queues it', async (
   await expect(page.getByText(/No meal queued up\./i)).toBeVisible();
 });
 
-test('planning a recommended recipe keeps recipe identity and weekly groceries intact', async ({
+test('recommended optional-source recipes require review before planning', async ({
   page,
 }) => {
   const seedResponse = await page.request.post('/api/db/migrate', {
@@ -400,49 +400,14 @@ test('planning a recommended recipe keeps recipe identity and weekly groceries i
     has: page.getByRole('heading', { name: 'Recommended next' }),
   });
   await expect(recommendationsSection.getByText('Teriyaki Chicken Casserole')).toBeVisible();
-  await recommendationsSection.getByRole('button', { name: 'Plan next' }).click();
-  await expect(page.getByText(/Planned next meal saved\./i)).toBeVisible();
-  const nutritionPlannedMealSection = page.locator('section').filter({
-    has: page.getByRole('heading', { name: 'Planned next meal' }),
-  });
-  await expect(nutritionPlannedMealSection.getByText('Teriyaki Chicken Casserole')).toBeVisible();
-  await expect(nutritionPlannedMealSection.getByText(/Meal type: dinner/i)).toBeVisible();
-  await expect(nutritionPlannedMealSection.getByText(/Calories: 0/i)).toHaveCount(0);
-  await expect(nutritionPlannedMealSection.getByText(/Protein: 0/i)).toHaveCount(0);
-
-  await page.goto('/plan');
-  const weekBoardSection = page.locator('section').filter({
-    has: page.getByRole('heading', { name: 'Week board' }),
-  });
-  await expect(weekBoardSection.getByText('Teriyaki Chicken Casserole')).toBeVisible();
-  await expect(page.getByText(/dinner · Japanese/i)).toBeVisible();
-  await expect(page.getByText('soy sauce')).toBeVisible();
-  await expect(page.getByText('chicken breast')).toBeVisible();
-
-  await page.goto('/today');
-  const plannedMealSection = page.locator('section').filter({
-    has: page.getByRole('heading', { name: 'Planned next meal' }),
-  });
-  await expect(plannedMealSection.getByText('Teriyaki Chicken Casserole')).toBeVisible();
-  await expect(plannedMealSection.getByText(`Meal type: dinner`)).toBeVisible();
-  await expect(plannedMealSection.getByText(/3\/4 cup soy sauce/i)).toBeVisible();
-  await expect(plannedMealSection.getByText(/Calories: 0/i)).toHaveCount(0);
-  await expect(plannedMealSection.getByText(/Protein: 0/i)).toHaveCount(0);
-
-  const nutritionPulseSection = page.locator('section').filter({
-    has: page.getByRole('heading', { name: 'Nutrition pulse' }),
-  });
-  await expect(nutritionPulseSection.getByText(/If you log the planned meal next:/i)).toHaveCount(
-    0
-  );
-  await expect(nutritionPulseSection.getByText(/Planned next:/i)).toHaveCount(0);
-  await expect(nutritionPulseSection.getByText(/Protein is still low so far\./i)).toHaveCount(0);
+  await expect(recommendationsSection.getByText(/Source: TheMealDB/i)).toBeVisible();
+  await expect(recommendationsSection.getByText(/Posture: optional/i)).toBeVisible();
   await expect(
-    nutritionPulseSection.getByText(/nutrition totals are still unknown/i)
+    recommendationsSection.getByRole('button', { name: 'Load recipe' })
   ).toBeVisible();
   await expect(
-    page.getByText(/changes today's intake more than another unplanned snack/i)
-  ).toHaveCount(0);
+    recommendationsSection.getByRole('button', { name: 'Review first' })
+  ).toBeDisabled();
 });
 
 test('nutrition planning replaces stale planned-food slots instead of leaving the handoff broken', async ({
@@ -2872,25 +2837,6 @@ test('saving a recipe-loaded draft as a custom food does not fabricate zero macr
     0
   );
 
-  await page.getByLabel('Food search').fill('teriyaki');
-  await page.getByRole('button', { name: 'Search foods' }).click();
-
-  const mealLoggingSection = page.locator('section').filter({
-    has: page.getByRole('heading', { name: 'Meal logging' }),
-  });
-  const localSearchResult = mealLoggingSection.locator('.match-list').first().locator('li').first();
-  await expect(localSearchResult.getByText('Teriyaki Chicken Casserole')).toBeVisible();
-  await expect(localSearchResult.getByText(/Nutrition totals unknown\./i)).toBeVisible();
-  await expect(localSearchResult.getByText(/0 kcal/i)).toHaveCount(0);
-  await expect(localSearchResult.getByText(/0g protein/i)).toHaveCount(0);
-
-  await localSearchResult.getByRole('button', { name: 'Use match' }).click();
-  await expect(page.getByLabel('Meal name')).toHaveValue('Teriyaki Chicken Casserole');
-  await expect(page.getByLabel('Calories')).toHaveValue('');
-  await expect(page.getByLabel('Protein')).toHaveValue('');
-  await expect(page.getByLabel('Fiber')).toHaveValue('');
-  await expect(page.getByLabel('Carbs')).toHaveValue('');
-  await expect(page.getByLabel('Fat')).toHaveValue('');
 });
 
 test('saving a fresh name-only custom food does not fabricate zero macros', async ({ page }) => {

--- a/tests/features/e2e/today-handoffs.e2e.ts
+++ b/tests/features/e2e/today-handoffs.e2e.ts
@@ -351,9 +351,7 @@ test('today can clear a planned meal handoff after nutrition queues it', async (
   await expect(page.getByText(/No meal queued up\./i)).toBeVisible();
 });
 
-test('recommended optional-source recipes require review before planning', async ({
-  page,
-}) => {
+test('recommended optional-source recipes require review before planning', async ({ page }) => {
   const seedResponse = await page.request.post('/api/db/migrate', {
     data: {
       snapshot: {
@@ -402,12 +400,8 @@ test('recommended optional-source recipes require review before planning', async
   await expect(recommendationsSection.getByText('Teriyaki Chicken Casserole')).toBeVisible();
   await expect(recommendationsSection.getByText(/Source: TheMealDB/i)).toBeVisible();
   await expect(recommendationsSection.getByText(/Posture: optional/i)).toBeVisible();
-  await expect(
-    recommendationsSection.getByRole('button', { name: 'Load recipe' })
-  ).toBeVisible();
-  await expect(
-    recommendationsSection.getByRole('button', { name: 'Review first' })
-  ).toBeDisabled();
+  await expect(recommendationsSection.getByRole('button', { name: 'Load recipe' })).toBeVisible();
+  await expect(recommendationsSection.getByRole('button', { name: 'Review first' })).toBeDisabled();
 });
 
 test('nutrition planning replaces stale planned-food slots instead of leaving the handoff broken', async ({
@@ -2836,7 +2830,6 @@ test('saving a recipe-loaded draft as a custom food does not fabricate zero macr
   await expect(recommendationsSection.getByText(/good fit for a steadier-energy day/i)).toHaveCount(
     0
   );
-
 });
 
 test('saving a fresh name-only custom food does not fabricate zero macros', async ({ page }) => {

--- a/tests/features/unit/golden/__snapshots__/migration-parity.test.ts.snap
+++ b/tests/features/unit/golden/__snapshots__/migration-parity.test.ts.snap
@@ -241,6 +241,7 @@ exports[`migration golden parity > matches current page-state outputs for seeded
     },
     "symptomForm": {
       "note": "",
+      "referenceUrl": "",
       "severity": "3",
       "symptom": "",
     },
@@ -249,6 +250,7 @@ exports[`migration golden parity > matches current page-state outputs for seeded
       "defaultUnit": "",
       "label": "",
       "note": "",
+      "referenceUrl": "",
       "templateType": "supplement",
     },
   },
@@ -373,6 +375,7 @@ exports[`migration golden parity > matches current page-state outputs for seeded
       "healthHighlights": [
         "Low sleep lined up with higher anxiety on 2026-03-31.",
       ],
+      "healthReferenceLinks": [],
       "journalHighlights": [
         "Evening review on 2026-03-31: Crowded store and headache drained the afternoon.",
       ],
@@ -430,6 +433,7 @@ exports[`migration golden parity > matches current page-state outputs for seeded
         "weekStart": "2026-03-30",
       },
       "sobrietyStreak": 1,
+      "symptomReferenceLinks": [],
       "weeklyDecisionCards": [
         {
           "confidence": "high",

--- a/tests/features/unit/golden/migration-parity.test.ts
+++ b/tests/features/unit/golden/migration-parity.test.ts
@@ -164,11 +164,14 @@ async function seedGoldenDataset(db: InMemoryTestHealthRuntime) {
     linkedEventIds: [],
   });
 
-  const batch = await previewImport(db, {
+  await previewImport(db, {
     sourceType: 'healthkit-companion',
     rawText: HEALTHKIT_BUNDLE_JSON,
   });
-  await commitImportBatch(db, batch.id);
+  await commitImportBatch(db, {
+    sourceType: 'healthkit-companion',
+    rawText: HEALTHKIT_BUNDLE_JSON,
+  });
 }
 
 describe('migration golden parity', () => {
@@ -209,7 +212,8 @@ describe('migration golden parity', () => {
     });
 
     const committed = await commitImportsPage(previewed, {
-      commitImportBatch: (batchId) => commitImportBatch(db, batchId),
+      getOwnerProfile: () => OWNER_PROFILE,
+      commitImportBatch: (input) => commitImportBatch(db, input),
     });
 
     const golden = stripKeys({

--- a/tests/features/unit/health/client.test.ts
+++ b/tests/features/unit/health/client.test.ts
@@ -10,13 +10,26 @@ describe('health client', () => {
   it('routes health actions through the feature action client with the expected payloads', async () => {
     const action = vi.fn();
     const stateAction = vi.fn();
+    const request = vi.fn(async () => ({
+      suggestions: [{ label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' }],
+      notice: 'Suggestions from Clinical Tables Conditions.',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+    }));
     const createFeatureActionClient = vi.fn(() => ({
       action,
       stateAction,
     }));
+    const createFeatureRequestClient = vi.fn(() => ({
+      request,
+    }));
 
     vi.doMock('$lib/core/http/feature-client', () => ({
       createFeatureActionClient,
+      createFeatureRequestClient,
     }));
 
     const client = await import('../../../../src/lib/features/health/client.ts');
@@ -27,6 +40,7 @@ describe('health client', () => {
         symptom: 'Headache',
         severity: '4',
         note: 'After lunch',
+        referenceUrl: '',
       },
       anxietyForm: {
         intensity: '4',
@@ -45,6 +59,7 @@ describe('health client', () => {
         defaultDose: '2',
         defaultUnit: 'capsules',
         note: 'Evening stack',
+        referenceUrl: '',
       },
     };
 
@@ -54,8 +69,30 @@ describe('health client', () => {
     await client.saveSleepNotePage(state);
     await client.saveTemplatePage(state);
     await client.quickLogTemplatePage(state, 'template-1');
+    await expect(client.searchHealthSymptomSuggestions('head')).resolves.toEqual({
+      suggestions: [
+        { label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' },
+      ],
+      notice: 'Suggestions from Clinical Tables Conditions.',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+    });
+    await expect(client.searchHealthMedicationSuggestions('metformin')).resolves.toEqual({
+      suggestions: [{ label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' }],
+      notice: 'Suggestions from Clinical Tables Conditions.',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+    });
 
     expect(createFeatureActionClient).toHaveBeenCalledWith('/api/health');
+    expect(createFeatureRequestClient).toHaveBeenCalledWith('/api/health/search-symptoms');
+    expect(createFeatureRequestClient).toHaveBeenCalledWith('/api/health/search-medications');
     expect(action).toHaveBeenCalledWith('load', expect.any(Function), { localDay: '2026-04-04' });
     expect(stateAction).toHaveBeenNthCalledWith(1, 'saveSymptom', state, expect.any(Function));
     expect(stateAction).toHaveBeenNthCalledWith(2, 'saveAnxiety', state, expect.any(Function));
@@ -68,5 +105,6 @@ describe('health client', () => {
       expect.any(Function),
       { templateId: 'template-1' }
     );
+    expect(request).toHaveBeenCalledWith({ query: 'head' }, expect.any(Function));
   });
 });

--- a/tests/features/unit/health/client.test.ts
+++ b/tests/features/unit/health/client.test.ts
@@ -70,9 +70,7 @@ describe('health client', () => {
     await client.saveTemplatePage(state);
     await client.quickLogTemplatePage(state, 'template-1');
     await expect(client.searchHealthSymptomSuggestions('head')).resolves.toEqual({
-      suggestions: [
-        { label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' },
-      ],
+      suggestions: [{ label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' }],
       notice: 'Suggestions from Clinical Tables Conditions.',
       metadata: {
         provenance: [],

--- a/tests/features/unit/health/clinical-tables.test.ts
+++ b/tests/features/unit/health/clinical-tables.test.ts
@@ -57,9 +57,9 @@ describe('clinical tables condition adapter', () => {
   });
 
   it('requests the documented Clinical Tables fields for condition suggestions', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(JSON.stringify([0, [], null, []]))
-    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify([0, [], null, []])));
 
     await searchClinicalConditionSuggestions('head', fetchImpl);
 
@@ -69,21 +69,23 @@ describe('clinical tables condition adapter', () => {
   });
 
   it('ignores malformed record tuples and keeps only rows with a non-empty label', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          4,
-          [],
-          null,
-          [
-            ['Headache', 'R51', 'Headache'],
-            [undefined, 'R51.9', 'Headache disorder'],
-            ['   ', 'R42', 'Dizziness'],
-            'not-a-tuple',
-          ],
-        ])
-      )
-    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            4,
+            [],
+            null,
+            [
+              ['Headache', 'R51', 'Headache'],
+              [undefined, 'R51.9', 'Headache disorder'],
+              ['   ', 'R42', 'Dizziness'],
+              'not-a-tuple',
+            ],
+          ])
+        )
+      );
 
     await expect(searchClinicalConditionSuggestions('head', fetchImpl)).resolves.toEqual([
       expect.objectContaining({
@@ -122,16 +124,11 @@ describe('clinical tables condition adapter', () => {
   });
 
   it('trims documented label and code fields before returning suggestions', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          1,
-          [],
-          null,
-          [['  Headache  ', '  R51  ', 'Headache']],
-        ])
-      )
-    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify([1, [], null, [['  Headache  ', '  R51  ', 'Headache']]]))
+      );
 
     await expect(searchClinicalConditionSuggestions('head', fetchImpl)).resolves.toEqual([
       expect.objectContaining({
@@ -143,18 +140,15 @@ describe('clinical tables condition adapter', () => {
   });
 
   it('returns a metadata-bearing envelope for successful suggestion searches', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          1,
-          [],
-          null,
-          [['Headache', 'R51', 'Headache']],
-        ])
-      )
-    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify([1, [], null, [['Headache', 'R51', 'Headache']]]))
+      );
 
-    await expect(searchClinicalConditionSuggestionsWithMetadata('head', fetchImpl)).resolves.toEqual({
+    await expect(
+      searchClinicalConditionSuggestionsWithMetadata('head', fetchImpl)
+    ).resolves.toEqual({
       suggestions: [
         {
           label: 'Headache',
@@ -201,9 +195,13 @@ describe('clinical tables condition adapter', () => {
   });
 
   it('returns degraded metadata instead of throwing when Clinical Tables is unavailable', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('Clinical Tables unavailable'));
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('Clinical Tables unavailable'));
 
-    await expect(searchClinicalConditionSuggestionsWithMetadata('head', fetchImpl)).resolves.toEqual({
+    await expect(
+      searchClinicalConditionSuggestionsWithMetadata('head', fetchImpl)
+    ).resolves.toEqual({
       suggestions: [],
       notice: 'Clinical condition suggestions unavailable right now.',
       metadata: expect.objectContaining({
@@ -214,16 +212,11 @@ describe('clinical tables condition adapter', () => {
   });
 
   it('applies a timeout signal to outbound Clinical Tables requests', async () => {
-    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          1,
-          [],
-          null,
-          [['Headache', 'R51', 'Headache']],
-        ])
-      )
-    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        new Response(JSON.stringify([1, [], null, [['Headache', 'R51', 'Headache']]]))
+      );
 
     await searchClinicalConditionSuggestions('head', fetchImpl);
 

--- a/tests/features/unit/health/clinical-tables.test.ts
+++ b/tests/features/unit/health/clinical-tables.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  searchClinicalConditionSuggestions,
+  searchClinicalConditionSuggestionsWithMetadata,
+} from '$lib/server/health/clinical-tables';
+import { buildMedlinePlusProblemLink } from '$lib/server/health/medlineplus';
+
+describe('clinical tables condition adapter', () => {
+  it('parses condition suggestions into a stable symptom suggestion shape', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          2,
+          ['Headache', 'Headache disorder'],
+          null,
+          [
+            ['Headache', 'R51', 'Headache'],
+            ['Headache disorder', 'R51.9', 'Headache disorder'],
+          ],
+        ])
+      )
+    );
+
+    const results = await searchClinicalConditionSuggestions('head', fetchImpl);
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        label: 'Headache',
+        code: 'R51',
+        sourceName: 'Clinical Tables Conditions',
+      }),
+      expect.objectContaining({
+        label: 'Headache disorder',
+        code: 'R51.9',
+        sourceName: 'Clinical Tables Conditions',
+      }),
+    ]);
+  });
+
+  it('returns an empty list for blank queries', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(searchClinicalConditionSuggestions('   ', fetchImpl)).resolves.toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when Clinical Tables responds with a malformed payload', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          broken: true,
+        })
+      )
+    );
+
+    await expect(searchClinicalConditionSuggestions('head', fetchImpl)).resolves.toEqual([]);
+  });
+
+  it('requests the documented Clinical Tables fields for condition suggestions', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify([0, [], null, []]))
+    );
+
+    await searchClinicalConditionSuggestions('head', fetchImpl);
+
+    const requestUrl = String(fetchImpl.mock.calls[0]?.[0] ?? '');
+    expect(requestUrl).toContain('sf=consumer_name%2Cprimary_name');
+    expect(requestUrl).toContain('df=primary_name%2Cicd10cm%2Cconsumer_name');
+  });
+
+  it('ignores malformed record tuples and keeps only rows with a non-empty label', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          4,
+          [],
+          null,
+          [
+            ['Headache', 'R51', 'Headache'],
+            [undefined, 'R51.9', 'Headache disorder'],
+            ['   ', 'R42', 'Dizziness'],
+            'not-a-tuple',
+          ],
+        ])
+      )
+    );
+
+    await expect(searchClinicalConditionSuggestions('head', fetchImpl)).resolves.toEqual([
+      expect.objectContaining({
+        label: 'Headache',
+        code: 'R51',
+        sourceName: 'Clinical Tables Conditions',
+      }),
+    ]);
+  });
+
+  it('omits code when the documented code field is blank or whitespace', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          2,
+          [],
+          null,
+          [
+            ['Headache', '   ', 'Headache'],
+            ['Dizziness', '', 'Dizziness'],
+          ],
+        ])
+      )
+    );
+
+    await expect(searchClinicalConditionSuggestions('head', fetchImpl)).resolves.toEqual([
+      {
+        label: 'Headache',
+        sourceName: 'Clinical Tables Conditions',
+      },
+      {
+        label: 'Dizziness',
+        sourceName: 'Clinical Tables Conditions',
+      },
+    ]);
+  });
+
+  it('trims documented label and code fields before returning suggestions', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          1,
+          [],
+          null,
+          [['  Headache  ', '  R51  ', 'Headache']],
+        ])
+      )
+    );
+
+    await expect(searchClinicalConditionSuggestions('head', fetchImpl)).resolves.toEqual([
+      expect.objectContaining({
+        label: 'Headache',
+        code: 'R51',
+        sourceName: 'Clinical Tables Conditions',
+      }),
+    ]);
+  });
+
+  it('returns a metadata-bearing envelope for successful suggestion searches', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          1,
+          [],
+          null,
+          [['Headache', 'R51', 'Headache']],
+        ])
+      )
+    );
+
+    await expect(searchClinicalConditionSuggestionsWithMetadata('head', fetchImpl)).resolves.toEqual({
+      suggestions: [
+        {
+          label: 'Headache',
+          code: 'R51',
+          referenceUrl: buildMedlinePlusProblemLink('R51', 'Headache') ?? undefined,
+          sourceName: 'Clinical Tables Conditions',
+        },
+      ],
+      notice: 'Suggestions from Clinical Tables Conditions.',
+      metadata: expect.objectContaining({
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      }),
+    });
+  });
+
+  it('adds a MedlinePlus reference link only when the condition code is present', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          2,
+          [],
+          null,
+          [
+            ['Headache', 'R51', 'Headache'],
+            ['Dizziness', '   ', 'Dizziness'],
+          ],
+        ])
+      )
+    );
+
+    await expect(searchClinicalConditionSuggestions('head', fetchImpl)).resolves.toEqual([
+      {
+        label: 'Headache',
+        code: 'R51',
+        referenceUrl: buildMedlinePlusProblemLink('R51', 'Headache') ?? undefined,
+        sourceName: 'Clinical Tables Conditions',
+      },
+      {
+        label: 'Dizziness',
+        sourceName: 'Clinical Tables Conditions',
+      },
+    ]);
+  });
+
+  it('returns degraded metadata instead of throwing when Clinical Tables is unavailable', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('Clinical Tables unavailable'));
+
+    await expect(searchClinicalConditionSuggestionsWithMetadata('head', fetchImpl)).resolves.toEqual({
+      suggestions: [],
+      notice: 'Clinical condition suggestions unavailable right now.',
+      metadata: expect.objectContaining({
+        cacheStatus: 'none',
+        degradationStatus: 'degraded',
+      }),
+    });
+  });
+
+  it('applies a timeout signal to outbound Clinical Tables requests', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          1,
+          [],
+          null,
+          [['Headache', 'R51', 'Headache']],
+        ])
+      )
+    );
+
+    await searchClinicalConditionSuggestions('head', fetchImpl);
+
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/tests/features/unit/health/medlineplus.test.ts
+++ b/tests/features/unit/health/medlineplus.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMedlinePlusMedicationLink,
+  buildMedlinePlusProblemLink,
+} from '$lib/server/health/medlineplus';
+
+describe('medlineplus links', () => {
+  it('builds a MedlinePlus Connect application link for ICD-10 problem codes', () => {
+    expect(buildMedlinePlusProblemLink('R51', 'Headache')).toBe(
+      'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en'
+    );
+  });
+
+  it('builds a MedlinePlus Connect application link for RxNorm medication codes', () => {
+    expect(buildMedlinePlusMedicationLink('860975', 'Metformin 500 MG Oral Tablet')).toBe(
+      'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en'
+    );
+  });
+
+  it('returns null for blank medication codes', () => {
+    expect(buildMedlinePlusMedicationLink('   ', 'Metformin 500 MG Oral Tablet')).toBeNull();
+  });
+});

--- a/tests/features/unit/health/model.test.ts
+++ b/tests/features/unit/health/model.test.ts
@@ -4,6 +4,8 @@ import {
   createHealthEventRows,
   createSleepCardLines,
   describeHealthTemplate,
+  updateSymptomFormValue,
+  updateTemplateFormValue,
 } from '$lib/features/health/model';
 
 describe('health model', () => {
@@ -38,6 +40,8 @@ describe('health model', () => {
           symptom: 'Headache',
           severity: 4,
           note: 'After lunch',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
         },
       },
     ];
@@ -51,6 +55,8 @@ describe('health model', () => {
       title: 'Headache',
       badge: 'Severity 4/5',
       lines: ['After lunch'],
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
     });
     expect(
       createSleepCardLines({ localDay: '2026-04-02', events, templates: [], sleepEvent: events[0] })
@@ -129,6 +135,118 @@ describe('health model', () => {
       title: 'Magnesium glycinate',
       badge: 'Supplement',
       lines: ['2 capsules'],
+    });
+  });
+
+  it('surfaces a reference link on medication event rows when one exists', () => {
+    const events: HealthEvent[] = [
+      {
+        id: 'medication-1',
+        createdAt: '2026-04-02T12:00:00Z',
+        updatedAt: '2026-04-02T12:00:00Z',
+        sourceType: 'manual',
+        sourceApp: 'personal-health-cockpit',
+        sourceTimestamp: '2026-04-02T12:00:00Z',
+        localDay: '2026-04-02',
+        confidence: 1,
+        eventType: 'medication-dose',
+        value: 1,
+        unit: 'tablet',
+        payload: {
+          kind: 'template-dose',
+          templateId: 'template-1',
+          templateName: 'Metformin 500 MG Oral Tablet',
+          templateType: 'medication',
+          amount: 1,
+          unit: 'tablet',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+        },
+      },
+    ];
+
+    const rows = createHealthEventRows(events);
+    expect(rows[0]).toMatchObject({
+      title: 'Metformin 500 MG Oral Tablet',
+      badge: 'Medication',
+      lines: ['1 tablet'],
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+    });
+  });
+
+  it('clears suggestion reference urls when the identifying symptom or template fields change', () => {
+    expect(
+      updateSymptomFormValue(
+        {
+          symptom: 'Headache',
+          severity: '4',
+          note: 'After lunch',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+        },
+        'symptom',
+        'Migraine'
+      )
+    ).toMatchObject({
+      symptom: 'Migraine',
+      referenceUrl: '',
+    });
+
+    expect(
+      updateSymptomFormValue(
+        {
+          symptom: 'Headache',
+          severity: '4',
+          note: 'After lunch',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+        },
+        'note',
+        'Worse after dinner'
+      )
+    ).toMatchObject({
+      note: 'Worse after dinner',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+    });
+
+    expect(
+      updateTemplateFormValue(
+        {
+          label: 'Metformin 500 MG Oral Tablet',
+          templateType: 'medication',
+          defaultDose: '1',
+          defaultUnit: 'tablet',
+          note: 'With breakfast',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+        },
+        'label',
+        'Ibuprofen'
+      )
+    ).toMatchObject({
+      label: 'Ibuprofen',
+      referenceUrl: '',
+    });
+
+    expect(
+      updateTemplateFormValue(
+        {
+          label: 'Metformin 500 MG Oral Tablet',
+          templateType: 'medication',
+          defaultDose: '1',
+          defaultUnit: 'tablet',
+          note: 'With breakfast',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+        },
+        'templateType',
+        'supplement'
+      )
+    ).toMatchObject({
+      templateType: 'supplement',
+      referenceUrl: '',
     });
   });
 });

--- a/tests/features/unit/health/page-state-actions.test.ts
+++ b/tests/features/unit/health/page-state-actions.test.ts
@@ -24,6 +24,7 @@ describe('health page state and actions', () => {
         symptom: 'Nausea',
         severity: '2',
         note: 'Faded after breakfast',
+        referenceUrl: '',
       },
     });
     expect(state.saveNotice).toBe('Symptom logged.');
@@ -61,6 +62,7 @@ describe('health page state and actions', () => {
         defaultDose: '1',
         defaultUnit: 'softgel',
         note: 'Morning stack',
+        referenceUrl: '',
       },
     });
     expect(state.saveNotice).toBe('Template saved.');
@@ -73,6 +75,29 @@ describe('health page state and actions', () => {
       true
     );
     expect(await db.reviewSnapshots.count()).toBe(1);
+  });
+
+  it('carries a selected symptom reference link through the save action into the logged event', async () => {
+    const db = getDb();
+    const state = await loadHealthPage(db, '2026-04-02');
+
+    await saveSymptomPage(db, {
+      ...state,
+      symptomForm: {
+        symptom: 'Headache',
+        severity: '4',
+        note: 'After lunch',
+        referenceUrl:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+      },
+    });
+
+    const events = await db.healthEvents.toArray();
+    expect(events.find((event) => event.eventType === 'symptom')?.payload).toMatchObject({
+      symptom: 'Headache',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+    });
   });
 
   it('guards required symptom and sleep-note fields', async () => {

--- a/tests/features/unit/health/route.test.ts
+++ b/tests/features/unit/health/route.test.ts
@@ -9,7 +9,7 @@ describe('health route', () => {
 
   const mutationState = {
     localDay: '2026-04-04',
-    symptomForm: { symptom: 'Headache', severity: '4', note: 'After lunch' },
+    symptomForm: { symptom: 'Headache', severity: '4', note: 'After lunch', referenceUrl: '' },
     anxietyForm: {
       intensity: '4',
       trigger: 'Crowded store',
@@ -23,6 +23,7 @@ describe('health route', () => {
       defaultDose: '2',
       defaultUnit: 'capsules',
       note: 'Evening stack',
+      referenceUrl: '',
     },
   };
 
@@ -49,7 +50,7 @@ describe('health route', () => {
           localDay: '2026-04-04',
           snapshot: null,
           saveNotice: '',
-          symptomForm: { symptom: '', severity: '3', note: '' },
+          symptomForm: { symptom: '', severity: '3', note: '', referenceUrl: '' },
           anxietyForm: { intensity: '3', trigger: '', durationMinutes: '', note: '' },
           sleepNoteForm: { note: '', restfulness: '', context: '' },
           templateForm: {
@@ -58,6 +59,7 @@ describe('health route', () => {
             defaultDose: '',
             defaultUnit: '',
             note: '',
+            referenceUrl: '',
           },
         })),
       saveSymptomPageServer:
@@ -111,7 +113,7 @@ describe('health route', () => {
       localDay: '2026-04-04',
       snapshot: null,
       saveNotice: '',
-      symptomForm: { symptom: '', severity: '3', note: '' },
+      symptomForm: { symptom: '', severity: '3', note: '', referenceUrl: '' },
       anxietyForm: { intensity: '3', trigger: '', durationMinutes: '', note: '' },
       sleepNoteForm: { note: '', restfulness: '', context: '' },
       templateForm: {
@@ -120,6 +122,7 @@ describe('health route', () => {
         defaultDose: '',
         defaultUnit: '',
         note: '',
+        referenceUrl: '',
       },
     }));
     const { POST } = await importRoute({ loadHealthPageServer });
@@ -244,5 +247,71 @@ describe('health route', () => {
     expect(response.status).toBe(400);
     expect(await response.text()).toBe('Invalid health request payload.');
     expect(loadHealthPageServer).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes unsafe symptom reference urls before dispatching to the server action', async () => {
+    const saveSymptomPageServer = vi.fn(async (state: unknown) => ({
+      ...(state as object),
+      loading: false,
+      snapshot: null,
+      saveNotice: 'Symptom logged.',
+    }));
+    const { POST } = await importRoute({ saveSymptomPageServer });
+
+    const unsafeState = {
+      ...requestState,
+      symptomForm: {
+        ...requestState.symptomForm,
+        referenceUrl: 'javascript:alert(1)',
+      },
+    };
+
+    const response = await POST({
+      request: new Request('http://health.test/api/health', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'saveSymptom', state: unsafeState }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(saveSymptomPageServer).toHaveBeenCalledWith({
+      ...mutationState,
+      symptomForm: {
+        ...mutationState.symptomForm,
+        referenceUrl: '',
+      },
+    });
+  });
+
+  it('rejects non-finite and out-of-range health numeric inputs at the route boundary', async () => {
+    const saveSymptomPageServer = vi.fn();
+    const { POST } = await importRoute({ saveSymptomPageServer });
+
+    const invalidState = {
+      ...requestState,
+      symptomForm: {
+        ...requestState.symptomForm,
+        severity: 'Infinity',
+      },
+      anxietyForm: {
+        ...requestState.anxietyForm,
+        intensity: '12',
+      },
+      sleepNoteForm: {
+        ...requestState.sleepNoteForm,
+        restfulness: '-1',
+      },
+    };
+
+    const response = await POST({
+      request: new Request('http://health.test/api/health', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'saveSymptom', state: invalidState }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid health request payload.');
+    expect(saveSymptomPageServer).not.toHaveBeenCalled();
   });
 });

--- a/tests/features/unit/health/rxnorm.test.ts
+++ b/tests/features/unit/health/rxnorm.test.ts
@@ -11,8 +11,20 @@ describe('rxnorm adapter', () => {
         JSON.stringify({
           approximateGroup: {
             candidate: [
-              { rxcui: '860975', rxaui: '123', score: '95', rank: '1', name: 'Metformin 500 MG Oral Tablet' },
-              { rxcui: '617314', rxaui: '124', score: '88', rank: '2', name: 'Metformin 850 MG Oral Tablet' },
+              {
+                rxcui: '860975',
+                rxaui: '123',
+                score: '95',
+                rank: '1',
+                name: 'Metformin 500 MG Oral Tablet',
+              },
+              {
+                rxcui: '617314',
+                rxaui: '124',
+                score: '88',
+                rank: '2',
+                name: 'Metformin 850 MG Oral Tablet',
+              },
             ],
           },
         })
@@ -53,7 +65,9 @@ describe('rxnorm adapter', () => {
       )
     );
 
-    await expect(searchRxNormMedicationSuggestionsWithMetadata('metformin', fetchImpl)).resolves.toEqual({
+    await expect(
+      searchRxNormMedicationSuggestionsWithMetadata('metformin', fetchImpl)
+    ).resolves.toEqual({
       suggestions: [
         expect.objectContaining({
           label: 'Metformin 500 MG Oral Tablet',
@@ -170,7 +184,9 @@ describe('rxnorm adapter', () => {
   it('returns degraded metadata instead of throwing when RxNorm is unavailable', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('RxNorm unavailable'));
 
-    await expect(searchRxNormMedicationSuggestionsWithMetadata('metformin', fetchImpl)).resolves.toEqual({
+    await expect(
+      searchRxNormMedicationSuggestionsWithMetadata('metformin', fetchImpl)
+    ).resolves.toEqual({
       suggestions: [],
       notice: 'RxNorm suggestions unavailable right now.',
       metadata: expect.objectContaining({

--- a/tests/features/unit/health/rxnorm.test.ts
+++ b/tests/features/unit/health/rxnorm.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  searchRxNormMedicationSuggestions,
+  searchRxNormMedicationSuggestionsWithMetadata,
+} from '$lib/server/health/rxnorm';
+
+describe('rxnorm adapter', () => {
+  it('parses approximate term suggestions into a stable medication suggestion shape', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          approximateGroup: {
+            candidate: [
+              { rxcui: '860975', rxaui: '123', score: '95', rank: '1', name: 'Metformin 500 MG Oral Tablet' },
+              { rxcui: '617314', rxaui: '124', score: '88', rank: '2', name: 'Metformin 850 MG Oral Tablet' },
+            ],
+          },
+        })
+      )
+    );
+
+    const results = await searchRxNormMedicationSuggestions('metformin', fetchImpl);
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        label: 'Metformin 500 MG Oral Tablet',
+        code: '860975',
+        sourceName: 'RxNorm',
+      }),
+      expect.objectContaining({
+        label: 'Metformin 850 MG Oral Tablet',
+        code: '617314',
+        sourceName: 'RxNorm',
+      }),
+    ]);
+  });
+
+  it('returns an empty list for blank medication queries', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(searchRxNormMedicationSuggestions('   ', fetchImpl)).resolves.toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('returns a metadata-bearing envelope for successful medication suggestions', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          approximateGroup: {
+            candidate: [{ rxcui: '860975', name: 'Metformin 500 MG Oral Tablet' }],
+          },
+        })
+      )
+    );
+
+    await expect(searchRxNormMedicationSuggestionsWithMetadata('metformin', fetchImpl)).resolves.toEqual({
+      suggestions: [
+        expect.objectContaining({
+          label: 'Metformin 500 MG Oral Tablet',
+          code: '860975',
+          sourceName: 'RxNorm',
+        }),
+      ],
+      notice: 'Suggestions from RxNorm.',
+      metadata: expect.objectContaining({
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      }),
+    });
+  });
+
+  it('adds a MedlinePlus reference link only when the rxnorm code is present', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          approximateGroup: {
+            candidate: [
+              { rxcui: '860975', name: 'Metformin 500 MG Oral Tablet' },
+              { rxcui: '   ', name: 'Generic metformin oral tablet' },
+            ],
+          },
+        })
+      )
+    );
+
+    await expect(searchRxNormMedicationSuggestions('metformin', fetchImpl)).resolves.toEqual([
+      expect.objectContaining({
+        label: 'Metformin 500 MG Oral Tablet',
+        code: '860975',
+        referenceUrl:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+      }),
+      {
+        label: 'Generic metformin oral tablet',
+        sourceName: 'RxNorm',
+      },
+    ]);
+  });
+
+  it('ignores malformed candidates and keeps only rows with a non-empty label', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          approximateGroup: {
+            candidate: [
+              { rxcui: '860975', name: 'Metformin 500 MG Oral Tablet' },
+              { rxcui: '617314', name: '   ' },
+              'not-an-object',
+            ],
+          },
+        })
+      )
+    );
+
+    await expect(searchRxNormMedicationSuggestions('metformin', fetchImpl)).resolves.toEqual([
+      expect.objectContaining({
+        label: 'Metformin 500 MG Oral Tablet',
+        code: '860975',
+        sourceName: 'RxNorm',
+      }),
+    ]);
+  });
+
+  it('omits code when the rxnorm identifier is blank or whitespace', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          approximateGroup: {
+            candidate: [
+              { rxcui: '   ', name: 'Metformin 500 MG Oral Tablet' },
+              { rxcui: '', name: 'Metformin XR Oral Tablet' },
+            ],
+          },
+        })
+      )
+    );
+
+    await expect(searchRxNormMedicationSuggestions('metformin', fetchImpl)).resolves.toEqual([
+      {
+        label: 'Metformin 500 MG Oral Tablet',
+        sourceName: 'RxNorm',
+      },
+      {
+        label: 'Metformin XR Oral Tablet',
+        sourceName: 'RxNorm',
+      },
+    ]);
+  });
+
+  it('trims medication labels and codes before returning suggestions', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          approximateGroup: {
+            candidate: [{ rxcui: ' 860975 ', name: '  Metformin 500 MG Oral Tablet  ' }],
+          },
+        })
+      )
+    );
+
+    await expect(searchRxNormMedicationSuggestions('metformin', fetchImpl)).resolves.toEqual([
+      expect.objectContaining({
+        label: 'Metformin 500 MG Oral Tablet',
+        code: '860975',
+        sourceName: 'RxNorm',
+      }),
+    ]);
+  });
+
+  it('returns degraded metadata instead of throwing when RxNorm is unavailable', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('RxNorm unavailable'));
+
+    await expect(searchRxNormMedicationSuggestionsWithMetadata('metformin', fetchImpl)).resolves.toEqual({
+      suggestions: [],
+      notice: 'RxNorm suggestions unavailable right now.',
+      metadata: expect.objectContaining({
+        cacheStatus: 'none',
+        degradationStatus: 'degraded',
+      }),
+    });
+  });
+
+  it('applies a timeout signal to outbound RxNorm requests', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          approximateGroup: {
+            candidate: [{ rxcui: '860975', name: 'Metformin 500 MG Oral Tablet' }],
+          },
+        })
+      )
+    );
+
+    await searchRxNormMedicationSuggestions('metformin', fetchImpl);
+
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/tests/features/unit/health/search-medications.route.test.ts
+++ b/tests/features/unit/health/search-medications.route.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('health medication search route', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/server/health/rxnorm');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns an empty list for blank medication queries', async () => {
+    const searchRxNormMedicationSuggestionsWithMetadata = vi.fn(async () => ({
+      suggestions: [],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    }));
+    vi.doMock('$lib/server/health/rxnorm', () => ({
+      searchRxNormMedicationSuggestionsWithMetadata,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-medications', {
+        method: 'POST',
+        body: JSON.stringify({ query: '   ' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestions: [],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    });
+    expect(searchRxNormMedicationSuggestionsWithMetadata).not.toHaveBeenCalled();
+  });
+
+  it('delegates valid medication queries to the rxnorm adapter', async () => {
+    const searchRxNormMedicationSuggestionsWithMetadata = vi.fn(async () => ({
+      suggestions: [
+        { label: 'Metformin 500 MG Oral Tablet', code: '860975', sourceName: 'RxNorm' },
+      ],
+      notice: 'Suggestions from RxNorm.',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+    }));
+    vi.doMock('$lib/server/health/rxnorm', () => ({
+      searchRxNormMedicationSuggestionsWithMetadata,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-medications', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'metformin' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestions: [{ label: 'Metformin 500 MG Oral Tablet', code: '860975', sourceName: 'RxNorm' }],
+      notice: 'Suggestions from RxNorm.',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+    });
+    expect(searchRxNormMedicationSuggestionsWithMetadata).toHaveBeenCalledWith('metformin');
+  });
+
+  it('returns 400 for invalid medication search payloads', async () => {
+    vi.doMock('$lib/server/health/rxnorm', () => ({
+      searchRxNormMedicationSuggestionsWithMetadata: vi.fn(),
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-medications', {
+        method: 'POST',
+        body: JSON.stringify({ query: 42 }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid medication search request payload.');
+  });
+
+  it('returns degraded medication metadata instead of a server error when RxNorm fails', async () => {
+    const searchRxNormMedicationSuggestionsWithMetadata = vi.fn(async () => {
+      throw new Error('RxNorm unavailable');
+    });
+    vi.doMock('$lib/server/health/rxnorm', () => ({
+      searchRxNormMedicationSuggestionsWithMetadata,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-medications', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'metformin' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestions: [],
+      notice: 'RxNorm suggestions unavailable right now.',
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'rxnorm',
+            sourceName: 'RxNorm',
+            category: 'reference',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'none',
+        degradationStatus: 'degraded',
+      },
+    });
+    expect(searchRxNormMedicationSuggestionsWithMetadata).toHaveBeenCalledWith('metformin');
+  });
+});

--- a/tests/features/unit/health/search-medications.route.test.ts
+++ b/tests/features/unit/health/search-medications.route.test.ts
@@ -21,7 +21,8 @@ describe('health medication search route', () => {
       searchRxNormMedicationSuggestionsWithMetadata,
     }));
 
-    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const { POST } =
+      await import('../../../../src/routes/api/health/search-medications/+server.ts');
     const response = await POST({
       request: new Request('http://health.test/api/health/search-medications', {
         method: 'POST',
@@ -58,7 +59,8 @@ describe('health medication search route', () => {
       searchRxNormMedicationSuggestionsWithMetadata,
     }));
 
-    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const { POST } =
+      await import('../../../../src/routes/api/health/search-medications/+server.ts');
     const response = await POST({
       request: new Request('http://health.test/api/health/search-medications', {
         method: 'POST',
@@ -68,7 +70,9 @@ describe('health medication search route', () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
-      suggestions: [{ label: 'Metformin 500 MG Oral Tablet', code: '860975', sourceName: 'RxNorm' }],
+      suggestions: [
+        { label: 'Metformin 500 MG Oral Tablet', code: '860975', sourceName: 'RxNorm' },
+      ],
       notice: 'Suggestions from RxNorm.',
       metadata: {
         provenance: [],
@@ -84,7 +88,8 @@ describe('health medication search route', () => {
       searchRxNormMedicationSuggestionsWithMetadata: vi.fn(),
     }));
 
-    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const { POST } =
+      await import('../../../../src/routes/api/health/search-medications/+server.ts');
     const response = await POST({
       request: new Request('http://health.test/api/health/search-medications', {
         method: 'POST',
@@ -104,7 +109,8 @@ describe('health medication search route', () => {
       searchRxNormMedicationSuggestionsWithMetadata,
     }));
 
-    const { POST } = await import('../../../../src/routes/api/health/search-medications/+server.ts');
+    const { POST } =
+      await import('../../../../src/routes/api/health/search-medications/+server.ts');
     const response = await POST({
       request: new Request('http://health.test/api/health/search-medications', {
         method: 'POST',

--- a/tests/features/unit/health/search-symptoms.route.test.ts
+++ b/tests/features/unit/health/search-symptoms.route.test.ts
@@ -44,9 +44,7 @@ describe('health symptom search route', () => {
 
   it('delegates valid symptom queries to the clinical tables adapter', async () => {
     const searchClinicalConditionSuggestionsWithMetadata = vi.fn(async () => ({
-      suggestions: [
-        { label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' },
-      ],
+      suggestions: [{ label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' }],
       notice: 'Suggestions from Clinical Tables Conditions.',
       metadata: {
         provenance: [],

--- a/tests/features/unit/health/search-symptoms.route.test.ts
+++ b/tests/features/unit/health/search-symptoms.route.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('health symptom search route', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/server/health/clinical-tables');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns an empty list for blank symptom queries', async () => {
+    const searchClinicalConditionSuggestionsWithMetadata = vi.fn(async () => ({
+      suggestions: [],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    }));
+    vi.doMock('$lib/server/health/clinical-tables', () => ({
+      searchClinicalConditionSuggestionsWithMetadata,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-symptoms/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-symptoms', {
+        method: 'POST',
+        body: JSON.stringify({ query: '   ' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestions: [],
+      notice: '',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    });
+    expect(searchClinicalConditionSuggestionsWithMetadata).not.toHaveBeenCalled();
+  });
+
+  it('delegates valid symptom queries to the clinical tables adapter', async () => {
+    const searchClinicalConditionSuggestionsWithMetadata = vi.fn(async () => ({
+      suggestions: [
+        { label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' },
+      ],
+      notice: 'Suggestions from Clinical Tables Conditions.',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+    }));
+    vi.doMock('$lib/server/health/clinical-tables', () => ({
+      searchClinicalConditionSuggestionsWithMetadata,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-symptoms/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-symptoms', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'head' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestions: [{ label: 'Headache', code: 'R51', sourceName: 'Clinical Tables Conditions' }],
+      notice: 'Suggestions from Clinical Tables Conditions.',
+      metadata: {
+        provenance: [],
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      },
+    });
+    expect(searchClinicalConditionSuggestionsWithMetadata).toHaveBeenCalledWith('head');
+  });
+
+  it('returns 400 for invalid symptom search payloads', async () => {
+    vi.doMock('$lib/server/health/clinical-tables', () => ({
+      searchClinicalConditionSuggestionsWithMetadata: vi.fn(),
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-symptoms/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-symptoms', {
+        method: 'POST',
+        body: JSON.stringify({ query: 42 }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe('Invalid symptom search request payload.');
+  });
+
+  it('returns degraded symptom metadata instead of a server error when Clinical Tables fails', async () => {
+    const searchClinicalConditionSuggestionsWithMetadata = vi.fn(async () => {
+      throw new Error('Clinical Tables unavailable');
+    });
+    vi.doMock('$lib/server/health/clinical-tables', () => ({
+      searchClinicalConditionSuggestionsWithMetadata,
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/health/search-symptoms/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/health/search-symptoms', {
+        method: 'POST',
+        body: JSON.stringify({ query: 'head' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestions: [],
+      notice: 'Clinical condition suggestions unavailable right now.',
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'clinical-tables-conditions',
+            sourceName: 'Clinical Tables Conditions',
+            category: 'reference',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'none',
+        degradationStatus: 'degraded',
+      },
+    });
+    expect(searchClinicalConditionSuggestionsWithMetadata).toHaveBeenCalledWith('head');
+  });
+});

--- a/tests/features/unit/health/service.test.ts
+++ b/tests/features/unit/health/service.test.ts
@@ -38,6 +38,51 @@ describe('health service', () => {
     });
   });
 
+  it('persists a medication template reference link when saving a normalized medication template', async () => {
+    const db = getDb();
+    const template = await saveHealthTemplate(db, {
+      label: 'Metformin 500 MG Oral Tablet',
+      templateType: 'medication',
+      defaultDose: 1,
+      defaultUnit: 'tablet',
+      note: 'With breakfast',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+    });
+
+    expect(template).toMatchObject({
+      label: 'Metformin 500 MG Oral Tablet',
+      templateType: 'medication',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+    });
+  });
+
+  it('carries a saved medication template reference link into the quick-logged event payload', async () => {
+    const db = getDb();
+    const template = await saveHealthTemplate(db, {
+      label: 'Metformin 500 MG Oral Tablet',
+      templateType: 'medication',
+      defaultDose: 1,
+      defaultUnit: 'tablet',
+      note: 'With breakfast',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+    });
+
+    const event = await quickLogHealthTemplate(db, {
+      localDay: '2026-04-02',
+      templateId: template.id,
+    });
+
+    expect(event.payload).toMatchObject({
+      templateId: template.id,
+      templateName: 'Metformin 500 MG Oral Tablet',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+    });
+  });
+
   it('builds a daily health snapshot with imported sleep and manual health events only', async () => {
     const db = getDb();
     await db.healthEvents.bulkAdd([
@@ -96,5 +141,46 @@ describe('health service', () => {
       'sleep-note',
       'symptom',
     ]);
+  });
+
+  it('persists a symptom reference link when logging a suggested symptom', async () => {
+    const db = getDb();
+
+    const event = await logSymptomEvent(db, {
+      localDay: '2026-04-02',
+      symptom: 'Headache',
+      severity: 4,
+      note: 'After lunch',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+    });
+
+    expect(event.payload).toMatchObject({
+      symptom: 'Headache',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+    });
+  });
+
+  it('drops unsafe reference urls when saving templates and symptom events', async () => {
+    const db = getDb();
+    const template = await saveHealthTemplate(db, {
+      label: 'Unsafe template',
+      templateType: 'medication',
+      referenceUrl: 'javascript:alert(1)',
+    });
+
+    const event = await logSymptomEvent(db, {
+      localDay: '2026-04-02',
+      symptom: 'Unsafe symptom',
+      severity: 3,
+      referenceUrl: 'javascript:alert(1)',
+    });
+
+    expect(template.referenceUrl).toBeUndefined();
+    expect(event.payload).toMatchObject({
+      symptom: 'Unsafe symptom',
+      referenceUrl: undefined,
+    });
   });
 });

--- a/tests/features/unit/imports/intake-state.test.ts
+++ b/tests/features/unit/imports/intake-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ImportBatch } from '$lib/core/domain/types';
+import type { ImportBatch, ImportPreviewResult } from '$lib/core/domain/types';
 import type { ImportPayloadSummary } from '$lib/features/imports/core';
 import {
   allowsHelperLinks,
@@ -39,6 +39,16 @@ const STAGED_BATCH: ImportBatch = {
   updatedAt: '2026-04-02T08:00:00.000Z',
   sourceType: 'healthkit-companion',
   status: 'staged',
+};
+
+const PREVIEW_RESULT: ImportPreviewResult = {
+  sourceType: 'healthkit-companion',
+  status: 'preview',
+  summary: {
+    adds: 3,
+    duplicates: 0,
+    warnings: 0,
+  },
 };
 
 describe('imports intake state', () => {
@@ -82,7 +92,7 @@ describe('imports intake state', () => {
       origin: 'file',
       summary: READY_SUMMARY,
     });
-    const previewed = applyPreviewSuccessState(loaded, STAGED_BATCH);
+    const previewed = applyPreviewSuccessState(loaded, PREVIEW_RESULT);
     const edited = applyManualPayloadEditState(previewed, '{"connector":"healthkit-ios"}\n');
 
     expect(edited.payloadOrigin).toBe('manual');
@@ -129,14 +139,14 @@ describe('imports intake state', () => {
 
   it('tracks preview and commit result states separately from errors', () => {
     const state = createImportIntakeState();
-    const previewed = applyPreviewSuccessState(state, STAGED_BATCH);
-    const committed = applyCommitSuccessState(previewed, { ...STAGED_BATCH, status: 'committed' });
+    const previewed = applyPreviewSuccessState(state, PREVIEW_RESULT);
+    const committed = applyCommitSuccessState(previewed, null);
     const previewError = applyPreviewErrorState(committed, 'Preview failed.');
     const fileError = applyFileLoadErrorState(previewError, 'File upload failed.');
     const commitError = applyCommitErrorState(fileError, 'Commit failed.');
 
-    expect(previewed.latestPreview?.status).toBe('staged');
-    expect(committed.latestPreview?.status).toBe('committed');
+    expect(previewed.latestPreview?.status).toBe('preview');
+    expect(committed.latestPreview).toBeNull();
     expect(committed.saveNotice).toBe('Import committed.');
     expect(previewError.latestPreview).toBeNull();
     expect(fileError.selectedFileName).toBe('');

--- a/tests/features/unit/imports/page-state-actions.test.ts
+++ b/tests/features/unit/imports/page-state-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ImportBatch } from '$lib/core/domain/types';
+import type { ImportBatch, ImportPreviewResult } from '$lib/core/domain/types';
 import type { ImportPayloadSummary } from '$lib/features/imports/core';
 import {
   commitImportsPage,
@@ -32,6 +32,16 @@ const STAGED_BATCH: ImportBatch = {
   updatedAt: '2026-04-02T08:00:00.000Z',
   sourceType: 'healthkit-companion',
   status: 'staged',
+};
+
+const PREVIEW_RESULT: ImportPreviewResult = {
+  sourceType: 'healthkit-companion',
+  status: 'preview',
+  summary: {
+    adds: 3,
+    duplicates: 0,
+    warnings: 0,
+  },
 };
 
 describe('imports page state and actions', () => {
@@ -99,25 +109,26 @@ describe('imports page state and actions', () => {
       {
         getOwnerProfile: () => null,
         previewImport: async ({ sourceType }) => ({
-          ...STAGED_BATCH,
+          ...PREVIEW_RESULT,
           sourceType,
         }),
       }
     );
-    expect(previewed.intake.latestPreview?.status).toBe('staged');
-    expect(previewed.batches).toEqual(batches);
+    expect(previewed.intake.latestPreview?.status).toBe('preview');
+    expect(previewed.batches).toEqual([]);
 
     const committed = await commitImportsPage(
       {
         ...previewed,
-        intake: {
-          ...previewed.intake,
-          latestPreview: STAGED_BATCH,
-        },
       },
       {
-        commitImportBatch: async (batchId) => {
-          expect(batchId).toBe('batch-1');
+        getOwnerProfile: () => null,
+        commitImportBatch: async (input) => {
+          expect(input).toEqual({
+            sourceType: 'healthkit-companion',
+            rawText: '{"entries":[]}',
+            ownerProfile: null,
+          });
           return {
             ...STAGED_BATCH,
             status: 'committed',
@@ -125,8 +136,9 @@ describe('imports page state and actions', () => {
         },
       }
     );
-    expect(committed.intake.latestPreview?.status).toBe('committed');
+    expect(committed.intake.latestPreview).toBeNull();
     expect(committed.intake.saveNotice).toBe('Import committed.');
+    expect(committed.batches[0]?.status).toBe('committed');
   });
 
   it('keeps successful preview and commit state even if batch refetch would fail', async () => {
@@ -134,21 +146,22 @@ describe('imports page state and actions', () => {
       applyImportsManualPayloadEdit(createImportsPageState(), '{"entries":[]}'),
       {
         getOwnerProfile: () => null,
-        previewImport: async () => STAGED_BATCH,
+        previewImport: async () => PREVIEW_RESULT,
       }
     );
 
-    expect(previewed.intake.latestPreview?.id).toBe('batch-1');
-    expect(previewed.batches).toEqual([STAGED_BATCH]);
+    expect(previewed.intake.latestPreview?.status).toBe('preview');
+    expect(previewed.batches).toEqual([]);
 
     const committed = await commitImportsPage(previewed, {
+      getOwnerProfile: () => null,
       commitImportBatch: async () => ({
         ...STAGED_BATCH,
         status: 'committed',
       }),
     });
 
-    expect(committed.intake.latestPreview?.status).toBe('committed');
+    expect(committed.intake.latestPreview).toBeNull();
     expect(committed.batches[0]?.status).toBe('committed');
     expect(committed.intake.errorNotice).toBe('');
   });

--- a/tests/features/unit/imports/route.test.ts
+++ b/tests/features/unit/imports/route.test.ts
@@ -17,11 +17,9 @@ describe('imports route', () => {
       previewImportServer:
         overrides.previewImportServer ??
         vi.fn(async () => ({
-          id: 'batch-1',
-          createdAt: '2026-04-02T08:00:00.000Z',
-          updatedAt: '2026-04-02T08:00:00.000Z',
           sourceType: 'healthkit-companion',
-          status: 'staged',
+          status: 'preview',
+          summary: { adds: 3, duplicates: 0, warnings: 0 },
         })),
       commitImportBatchServer:
         overrides.commitImportBatchServer ??
@@ -65,11 +63,9 @@ describe('imports route', () => {
 
   it('previews imports through the server imports service', async () => {
     const previewImportServer = vi.fn(async () => ({
-      id: 'batch-2',
-      createdAt: '2026-04-02T08:00:00.000Z',
-      updatedAt: '2026-04-02T08:00:00.000Z',
       sourceType: 'day-one-json',
-      status: 'staged',
+      status: 'preview',
+      summary: { adds: 1, duplicates: 0, warnings: 0 },
     }));
     const { POST } = await importRoute({ previewImportServer });
     const input = {
@@ -86,7 +82,13 @@ describe('imports route', () => {
     } as Parameters<typeof POST>[0]);
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(expect.objectContaining({ id: 'batch-2' }));
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        sourceType: 'day-one-json',
+        status: 'preview',
+        summary: { adds: 1, duplicates: 0, warnings: 0 },
+      })
+    );
     expect(previewImportServer).toHaveBeenCalledWith(input);
   });
 
@@ -97,19 +99,31 @@ describe('imports route', () => {
       updatedAt: '2026-04-02T08:05:00.000Z',
       sourceType: 'healthkit-companion',
       status: 'committed',
+      summary: { adds: 3, duplicates: 0, warnings: 0 },
     }));
     const { POST } = await importRoute({ commitImportBatchServer });
 
     const response = await POST({
       request: new Request('http://health.test/api/imports', {
         method: 'POST',
-        body: JSON.stringify({ action: 'commit', batchId: 'batch-3' }),
+        body: JSON.stringify({
+          action: 'commit',
+          input: {
+            sourceType: 'healthkit-companion',
+            rawText: '{}',
+            ownerProfile: null,
+          },
+        }),
       }),
     } as Parameters<typeof POST>[0]);
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(expect.objectContaining({ status: 'committed' }));
-    expect(commitImportBatchServer).toHaveBeenCalledWith('batch-3');
+    expect(commitImportBatchServer).toHaveBeenCalledWith({
+      sourceType: 'healthkit-companion',
+      rawText: '{}',
+      ownerProfile: null,
+    });
   });
 
   it('returns 400 for invalid import payloads and service errors', async () => {
@@ -142,6 +156,15 @@ describe('imports route', () => {
     } as Parameters<typeof POST>[0]);
     expect(invalidSourceType.status).toBe(400);
     expect(await invalidSourceType.text()).toBe('Invalid import request payload.');
+
+    const invalidCommit = await POST({
+      request: new Request('http://health.test/api/imports', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'commit', batchId: 'batch-1' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+    expect(invalidCommit.status).toBe(400);
+    expect(await invalidCommit.text()).toBe('Invalid import request payload.');
 
     const failing = await POST({
       request: new Request('http://health.test/api/imports', {

--- a/tests/features/unit/imports/server.service.test.ts
+++ b/tests/features/unit/imports/server.service.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('imports server service', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/server/db/drizzle/client');
+    vi.doUnmock('$lib/server/db/drizzle/schema');
+    vi.doUnmock('$lib/server/db/drizzle/mirror');
+    vi.doUnmock('$lib/server/review/service');
+    vi.doUnmock('$lib/features/imports/analyze');
+    vi.doUnmock('$lib/features/imports/parsers');
+    vi.doUnmock('$lib/features/integrations/connectors/healthkit');
+    vi.doUnmock('$lib/features/integrations/connectors/smart-fhir');
+    vi.doUnmock('$lib/features/integrations/identity/patient-match');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('keeps import preview ephemeral without writing batches or artifacts', async () => {
+    const transaction = vi.fn((callback: (tx: { mocked: true }) => unknown) => callback({ mocked: true }));
+    const upsertMirrorRecord = vi.fn();
+    const upsertMirrorRecords = vi.fn();
+
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { transaction } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { importBatches: {}, importArtifacts: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectAllMirrorRecords: vi.fn(async () => []),
+      selectMirrorRecordById: vi.fn(async () => undefined),
+      selectMirrorRecordsByField: vi.fn(async () => []),
+      selectMirrorRecordsByFieldValues: vi.fn(async () => []),
+      upsertMirrorRecord,
+      upsertMirrorRecordSync: upsertMirrorRecord,
+      upsertMirrorRecords,
+      upsertMirrorRecordsSync: upsertMirrorRecords,
+    }));
+    vi.doMock('$lib/server/review/service', () => ({
+      refreshWeeklyReviewArtifactsForDaysServer: vi.fn(),
+    }));
+    vi.doMock('$lib/features/imports/analyze', () => ({
+      analyzeImportPayload: vi.fn(() => ({
+        sourceType: 'day-one-json',
+        summary: {
+          status: 'ready',
+        },
+        journalEntries: [
+          {
+            id: 'entry-1',
+            createdAt: '2026-04-02T09:00:00Z',
+            updatedAt: '2026-04-02T09:00:00Z',
+            localDay: '2026-04-02',
+            entryType: 'freeform',
+            body: 'Morning reflection',
+            tags: [],
+            linkedEventIds: [],
+          },
+        ],
+      })),
+    }));
+    vi.doMock('$lib/features/imports/parsers', () => ({
+      parseAppleHealthXml: vi.fn(),
+      parseDayOneExport: vi.fn(),
+    }));
+    vi.doMock('$lib/features/integrations/connectors/healthkit', () => ({
+      importHealthKitCompanionBundle: vi.fn(),
+    }));
+    vi.doMock('$lib/features/integrations/connectors/smart-fhir', () => ({
+      importSmartFhirSandboxBundle: vi.fn(),
+    }));
+    vi.doMock('$lib/features/integrations/identity/patient-match', () => ({
+      resolveClinicalPatientMatch: vi.fn(),
+    }));
+
+    const { previewImportServer } =
+      await import('../../../../src/lib/server/imports/service.ts');
+
+    await previewImportServer({
+      sourceType: 'day-one-json',
+      rawText: '{"entries":[]}',
+    });
+
+    expect(transaction).not.toHaveBeenCalled();
+    expect(upsertMirrorRecord).not.toHaveBeenCalled();
+    expect(upsertMirrorRecords).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh review artifacts if import commit persistence fails inside the transaction', async () => {
+    const transaction = vi.fn((callback: (tx: { mocked: true }) => unknown) => callback({ mocked: true }));
+    const upsertMirrorRecord = vi.fn(() => {
+      throw new Error('write failed');
+    });
+    const refreshWeeklyReviewArtifactsForDaysServer = vi.fn();
+
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { transaction } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { importBatches: {}, importArtifacts: {}, healthEvents: {}, journalEntries: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectAllMirrorRecords: vi.fn(async () => []),
+      selectMirrorRecordById: vi.fn(async () => ({
+        id: 'batch-1',
+        createdAt: '2026-04-02T08:00:00.000Z',
+        updatedAt: '2026-04-02T08:00:00.000Z',
+        sourceType: 'healthkit-companion',
+        status: 'staged',
+      })),
+      selectMirrorRecordsByField: vi.fn(async () => [
+        {
+          id: 'artifact-1',
+          batchId: 'batch-1',
+          artifactType: 'healthEvent',
+          createdAt: '2026-04-02T08:00:00.000Z',
+          updatedAt: '2026-04-02T08:00:00.000Z',
+          fingerprint: 'fp-1',
+          payload: {
+            id: 'event-1',
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            localDay: '2026-04-02',
+            sourceType: 'import',
+            sourceApp: 'Test',
+            confidence: 1,
+            eventType: 'step-count',
+            value: 1000,
+          },
+          recordJson: '',
+        },
+      ]),
+      selectMirrorRecordsByFieldValues: vi.fn(async () => []),
+      upsertMirrorRecord,
+      upsertMirrorRecordSync: upsertMirrorRecord,
+      upsertMirrorRecords: vi.fn(),
+      upsertMirrorRecordsSync: vi.fn(),
+    }));
+    vi.doMock('$lib/server/review/service', () => ({
+      refreshWeeklyReviewArtifactsForDaysServer,
+    }));
+    vi.doMock('$lib/features/imports/analyze', () => ({
+      analyzeImportPayload: vi.fn(() => ({
+        sourceType: 'healthkit-companion',
+        summary: { status: 'ready' },
+        healthEvents: [
+          {
+            id: 'event-1',
+            createdAt: '2026-04-02T08:00:00.000Z',
+            updatedAt: '2026-04-02T08:00:00.000Z',
+            localDay: '2026-04-02',
+            sourceType: 'import',
+            sourceApp: 'Test',
+            confidence: 1,
+            eventType: 'step-count',
+            value: 1000,
+          },
+        ],
+      })),
+    }));
+    vi.doMock('$lib/features/imports/parsers', () => ({
+      parseAppleHealthXml: vi.fn(),
+      parseDayOneExport: vi.fn(),
+    }));
+    vi.doMock('$lib/features/integrations/connectors/healthkit', () => ({
+      importHealthKitCompanionBundle: vi.fn(),
+    }));
+    vi.doMock('$lib/features/integrations/connectors/smart-fhir', () => ({
+      importSmartFhirSandboxBundle: vi.fn(),
+    }));
+    vi.doMock('$lib/features/integrations/identity/patient-match', () => ({
+      resolveClinicalPatientMatch: vi.fn(),
+    }));
+
+    const { commitImportBatchServer } =
+      await import('../../../../src/lib/server/imports/service.ts');
+
+    await expect(
+      commitImportBatchServer({
+        sourceType: 'healthkit-companion',
+        rawText: '{}',
+      })
+    ).rejects.toThrow('write failed');
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(refreshWeeklyReviewArtifactsForDaysServer).not.toHaveBeenCalled();
+  });
+});

--- a/tests/features/unit/imports/server.service.test.ts
+++ b/tests/features/unit/imports/server.service.test.ts
@@ -16,7 +16,9 @@ describe('imports server service', () => {
   });
 
   it('keeps import preview ephemeral without writing batches or artifacts', async () => {
-    const transaction = vi.fn((callback: (tx: { mocked: true }) => unknown) => callback({ mocked: true }));
+    const transaction = vi.fn((callback: (tx: { mocked: true }) => unknown) =>
+      callback({ mocked: true })
+    );
     const upsertMirrorRecord = vi.fn();
     const upsertMirrorRecords = vi.fn();
 
@@ -73,8 +75,7 @@ describe('imports server service', () => {
       resolveClinicalPatientMatch: vi.fn(),
     }));
 
-    const { previewImportServer } =
-      await import('../../../../src/lib/server/imports/service.ts');
+    const { previewImportServer } = await import('../../../../src/lib/server/imports/service.ts');
 
     await previewImportServer({
       sourceType: 'day-one-json',
@@ -86,8 +87,86 @@ describe('imports server service', () => {
     expect(upsertMirrorRecords).not.toHaveBeenCalled();
   });
 
+  it('dedupes duplicate sourceRecordId values within same incoming server batch', async () => {
+    const selectMirrorRecordsByFieldValues = vi.fn(async () => []);
+
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: {} }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { healthEvents: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectAllMirrorRecords: vi.fn(async () => []),
+      selectMirrorRecordById: vi.fn(async () => undefined),
+      selectMirrorRecordsByField: vi.fn(async () => []),
+      selectMirrorRecordsByFieldValues,
+      upsertMirrorRecord: vi.fn(),
+      upsertMirrorRecordSync: vi.fn(),
+      upsertMirrorRecords: vi.fn(),
+      upsertMirrorRecordsSync: vi.fn(),
+    }));
+    vi.doMock('$lib/server/review/service', () => ({
+      refreshWeeklyReviewArtifactsForDaysServer: vi.fn(),
+    }));
+    vi.doMock('$lib/features/imports/analyze', () => ({
+      analyzeImportPayload: vi.fn(() => null),
+    }));
+    vi.doMock('$lib/features/imports/parsers', () => ({
+      parseAppleHealthXml: vi.fn(() => []),
+      parseDayOneExport: vi.fn(() => []),
+    }));
+    vi.doMock('$lib/features/integrations/connectors/healthkit', () => ({
+      importHealthKitCompanionBundle: vi.fn(() => ({ events: [] })),
+    }));
+    vi.doMock('$lib/features/integrations/connectors/smart-fhir', () => ({
+      importSmartFhirSandboxBundle: vi.fn(() => ({ events: [], patientIdentity: {} })),
+    }));
+    vi.doMock('$lib/features/integrations/identity/patient-match', () => ({
+      resolveClinicalPatientMatch: vi.fn(),
+    }));
+
+    const { dedupeImportedEventsServer } =
+      await import('../../../../src/lib/server/imports/service.ts');
+
+    const timestamp = '2026-04-02T08:00:00.000Z';
+    const result = await dedupeImportedEventsServer([
+      {
+        id: 'event-a',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        localDay: '2026-04-02',
+        sourceType: 'import',
+        sourceApp: 'Apple Health XML',
+        sourceRecordId: 'apple:record:1',
+        confidence: 0.95,
+        eventType: 'step-count',
+        value: 1000,
+      },
+      {
+        id: 'event-b',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        localDay: '2026-04-02',
+        sourceType: 'import',
+        sourceApp: 'Apple Health XML',
+        sourceRecordId: 'apple:record:1',
+        confidence: 0.95,
+        eventType: 'step-count',
+        value: 1000,
+      },
+    ]);
+
+    expect(selectMirrorRecordsByFieldValues).toHaveBeenCalledTimes(1);
+    expect(result.adds).toHaveLength(1);
+    expect(result.duplicates).toHaveLength(1);
+    expect(result.duplicates[0]?.id).toBe('event-b');
+  });
+
   it('does not refresh review artifacts if import commit persistence fails inside the transaction', async () => {
-    const transaction = vi.fn((callback: (tx: { mocked: true }) => unknown) => callback({ mocked: true }));
+    const transaction = vi.fn((callback: (tx: { mocked: true }) => unknown) =>
+      callback({ mocked: true })
+    );
     const upsertMirrorRecord = vi.fn(() => {
       throw new Error('write failed');
     });
@@ -97,7 +176,12 @@ describe('imports server service', () => {
       getServerDrizzleClient: () => ({ db: { transaction } }),
     }));
     vi.doMock('$lib/server/db/drizzle/schema', () => ({
-      drizzleSchema: { importBatches: {}, importArtifacts: {}, healthEvents: {}, journalEntries: {} },
+      drizzleSchema: {
+        importBatches: {},
+        importArtifacts: {},
+        healthEvents: {},
+        journalEntries: {},
+      },
     }));
     vi.doMock('$lib/server/db/drizzle/mirror', () => ({
       selectAllMirrorRecords: vi.fn(async () => []),

--- a/tests/features/unit/imports/source-config.test.ts
+++ b/tests/features/unit/imports/source-config.test.ts
@@ -36,10 +36,50 @@ describe('buildImportSourceCatalog', () => {
       'apple-health-xml',
       'day-one-json',
     ]);
-    expect(catalog.labels['healthkit-companion']).toBe('iPhone bundle / Shortcuts JSON');
+    expect(catalog.labels['healthkit-companion']).toBe('iPhone HealthKit Companion');
     expect(catalog.config['smart-fhir-sandbox'].sampleBundle?.filename).toBe(
       'sample-smart-fhir-bundle.json'
     );
+  });
+
+  it('derives the healthkit lane label from the device manifest so the source registry cannot drift', () => {
+    const catalog = buildImportSourceCatalog({
+      healthkitManifest: {
+        ...HEALTHKIT_MANIFEST,
+        label: 'Clinic-managed iPhone Export',
+      },
+      createSampleHealthKitBundle: () => ({ connector: 'healthkit' }),
+      createSampleSmartFhirBundle: () => ({ resourceType: 'Bundle' }),
+    });
+
+    expect(catalog.options.find((option) => option.value === 'healthkit-companion')).toEqual({
+      value: 'healthkit-companion',
+      label: 'Clinic-managed iPhone Export',
+    });
+    expect(catalog.labels['healthkit-companion']).toBe('Clinic-managed iPhone Export');
+  });
+
+  it('attaches source-registry import metadata for healthkit and smart sandbox lanes', () => {
+    const catalog = buildImportSourceCatalog({
+      healthkitManifest: HEALTHKIT_MANIFEST,
+      createSampleHealthKitBundle: () => ({ connector: 'healthkit' }),
+      createSampleSmartFhirBundle: () => ({ resourceType: 'Bundle' }),
+    });
+
+    expect(catalog.config['healthkit-companion']).toMatchObject({
+      sourceMetadata: {
+        sourceName: 'HealthKit Companion',
+        authMode: 'native-consent',
+        reliability: 'official',
+      },
+    });
+    expect(catalog.config['smart-fhir-sandbox']).toMatchObject({
+      sourceMetadata: {
+        sourceName: 'SMART on FHIR sandbox',
+        authMode: 'oauth2',
+        reliability: 'sandbox',
+      },
+    });
   });
 });
 

--- a/tests/features/unit/imports/store.test.ts
+++ b/tests/features/unit/imports/store.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { commitImportBatch, listImportBatches, previewImport } from '$lib/features/imports/store';
+import {
+  commitImportBatch,
+  dedupeImportedEvents,
+  listImportBatches,
+  previewImport,
+} from '$lib/features/imports/store';
 import { describeImportPayload } from '$lib/features/imports/analyze';
 import { inferImportSourceType } from '$lib/features/imports/detect';
 import { parseAppleHealthXml, parseDayOneExport } from '$lib/features/imports/parsers';
@@ -54,7 +59,9 @@ describe('imports store', () => {
     expect(records[0]?.createdAt).toBe(records[0]?.updatedAt);
     expect(records[0]?.createdAt).toBe(records[0]?.sourceTimestamp);
     expect(records[0]?.localDay).toBe(records[0]?.sourceTimestamp?.slice(0, 10));
-    expect(records[0]?.sourceRecordId).toBe(`iPhone:${records[0]?.sourceTimestamp}`);
+    expect(records[0]?.sourceRecordId).toBe(
+      `iPhone:HKQuantityTypeIdentifierStepCount:${records[0]?.sourceTimestamp}:${records[0]?.sourceTimestamp}:count:4321`
+    );
   });
 
   it('uses one fallback timestamp per Day One parse when creation dates are missing', () => {
@@ -66,6 +73,44 @@ describe('imports store', () => {
 
     expect(entries[0]?.createdAt).toBe(entries[0]?.updatedAt);
     expect(entries[0]?.localDay).toBe(entries[0]?.createdAt?.slice(0, 10));
+  });
+
+  it('dedupes duplicate sourceRecordId values within same incoming event batch', async () => {
+    const db = getDb();
+    const timestamp = '2026-04-02T08:00:00.000Z';
+
+    const result = await dedupeImportedEvents(db, [
+      {
+        id: 'event-a',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        sourceType: 'import',
+        sourceApp: 'Apple Health XML',
+        sourceRecordId: 'apple:record:1',
+        sourceTimestamp: timestamp,
+        localDay: '2026-04-02',
+        confidence: 0.95,
+        eventType: 'step-count',
+        value: 1000,
+      },
+      {
+        id: 'event-b',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        sourceType: 'import',
+        sourceApp: 'Apple Health XML',
+        sourceRecordId: 'apple:record:1',
+        sourceTimestamp: timestamp,
+        localDay: '2026-04-02',
+        confidence: 0.95,
+        eventType: 'step-count',
+        value: 1000,
+      },
+    ]);
+
+    expect(result.adds).toHaveLength(1);
+    expect(result.duplicates).toHaveLength(1);
+    expect(result.duplicates[0]?.id).toBe('event-b');
   });
 
   it('infers import source types from filename and content', () => {

--- a/tests/features/unit/imports/store.test.ts
+++ b/tests/features/unit/imports/store.test.ts
@@ -122,8 +122,17 @@ describe('imports store', () => {
       sourceType: 'apple-health-xml',
       rawText: APPLE_HEALTH_XML,
     });
-    expect(first.summary).toEqual({ adds: 2, duplicates: 0, warnings: 0 });
-    await commitImportBatch(db, first.id);
+    expect(first).toEqual({
+      sourceType: 'apple-health-xml',
+      status: 'preview',
+      summary: { adds: 2, duplicates: 0, warnings: 0 },
+    });
+    expect(await db.importBatches.count()).toBe(0);
+    expect(await db.importArtifacts.count()).toBe(0);
+    await commitImportBatch(db, {
+      sourceType: 'apple-health-xml',
+      rawText: APPLE_HEALTH_XML,
+    });
     expect(await db.healthEvents.count()).toBe(2);
     expect(await db.reviewSnapshots.count()).toBe(1);
 
@@ -136,9 +145,23 @@ describe('imports store', () => {
 
   it('commits Day One imports into journal entries', async () => {
     const db = getDb();
-    const batch = await previewImport(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
-    await commitImportBatch(db, batch.id);
+    const preview = await previewImport(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
+    expect(preview.status).toBe('preview');
+    expect(await db.importBatches.count()).toBe(0);
+    await commitImportBatch(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
     expect(await db.journalEntries.count()).toBe(1);
+  });
+
+  it('keeps Day One preview replay honest after the same entry was already imported', async () => {
+    const db = getDb();
+    const first = await previewImport(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
+    expect(first.summary).toEqual({ adds: 1, duplicates: 0, warnings: 0 });
+    expect(await db.importArtifacts.count()).toBe(0);
+    await commitImportBatch(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
+    expect(await db.journalEntries.count()).toBe(1);
+
+    const second = await previewImport(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
+    expect(second.summary).toEqual({ adds: 0, duplicates: 1, warnings: 0 });
   });
 
   it('stages HealthKit companion bundle previews and dedupes replay', async () => {
@@ -147,9 +170,18 @@ describe('imports store', () => {
       sourceType: 'healthkit-companion',
       rawText: HEALTHKIT_BUNDLE_JSON,
     });
-    expect(first.summary).toEqual({ adds: 3, duplicates: 0, warnings: 0 });
+    expect(first).toEqual({
+      sourceType: 'healthkit-companion',
+      status: 'preview',
+      summary: { adds: 3, duplicates: 0, warnings: 0 },
+    });
+    expect(await db.importBatches.count()).toBe(0);
+    expect(await db.importArtifacts.count()).toBe(0);
 
-    await commitImportBatch(db, first.id);
+    await commitImportBatch(db, {
+      sourceType: 'healthkit-companion',
+      rawText: HEALTHKIT_BUNDLE_JSON,
+    });
     expect(await db.reviewSnapshots.count()).toBe(1);
 
     const events = await db.healthEvents.toArray();
@@ -205,7 +237,7 @@ describe('imports store', () => {
 
   it('stages and commits SMART sandbox clinical events for the configured owner', async () => {
     const db = getDb();
-    const batch = await previewImport(db, {
+    const preview = await previewImport(db, {
       sourceType: 'smart-fhir-sandbox',
       rawText: SMART_FHIR_BUNDLE_JSON,
       ownerProfile: {
@@ -214,9 +246,20 @@ describe('imports store', () => {
       },
     });
 
-    expect(batch.summary).toEqual({ adds: 3, duplicates: 0, warnings: 0 });
+    expect(preview).toEqual({
+      sourceType: 'smart-fhir-sandbox',
+      status: 'preview',
+      summary: { adds: 3, duplicates: 0, warnings: 0 },
+    });
 
-    await commitImportBatch(db, batch.id);
+    await commitImportBatch(db, {
+      sourceType: 'smart-fhir-sandbox',
+      rawText: SMART_FHIR_BUNDLE_JSON,
+      ownerProfile: {
+        fullName: 'Pyro Example',
+        birthDate: '1990-01-01',
+      },
+    });
 
     const events = await db.healthEvents.toArray();
     expect(events).toHaveLength(3);
@@ -242,8 +285,8 @@ describe('imports store', () => {
 
   it('lists import batches newest first', async () => {
     const db = getDb();
-    await previewImport(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
-    await previewImport(db, { sourceType: 'apple-health-xml', rawText: APPLE_HEALTH_XML });
+    await commitImportBatch(db, { sourceType: 'day-one-json', rawText: DAY_ONE_JSON });
+    await commitImportBatch(db, { sourceType: 'apple-health-xml', rawText: APPLE_HEALTH_XML });
 
     const batches = await listImportBatches(db);
     expect(batches).toHaveLength(2);

--- a/tests/features/unit/integrations/controller.test.ts
+++ b/tests/features/unit/integrations/controller.test.ts
@@ -9,11 +9,14 @@ describe('integrations controller', () => {
 
   it('loads integrations controller state from imported events', async () => {
     const db = getDb();
-    const batch = await previewImport(db, {
+    await previewImport(db, {
       sourceType: 'healthkit-companion',
       rawText: HEALTHKIT_BUNDLE_JSON,
     });
-    await commitImportBatch(db, batch.id);
+    await commitImportBatch(db, {
+      sourceType: 'healthkit-companion',
+      rawText: HEALTHKIT_BUNDLE_JSON,
+    });
 
     const state = await loadIntegrationsPage(db);
     expect(state.loading).toBe(false);

--- a/tests/features/unit/movement/search-service.test.ts
+++ b/tests/features/unit/movement/search-service.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('movement search service', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/server/movement/wger');
+    vi.doUnmock('$lib/server/planning/store');
+    vi.doUnmock('$lib/server/db/drizzle/client');
+    vi.doUnmock('$lib/server/db/drizzle/schema');
+    vi.doUnmock('$lib/server/db/drizzle/mirror');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns cached local exercise matches before calling wger', async () => {
+    const searchWgerExercises = vi.fn(async () => [
+      {
+        id: 'wger:remote-1',
+        createdAt: '1970-01-01T00:00:00.000Z',
+        updatedAt: '1970-01-01T00:00:00.000Z',
+        sourceType: 'wger' as const,
+        externalId: 'remote-1',
+        title: 'Remote Goblet squat',
+        muscleGroups: ['Quadriceps'],
+        equipment: ['Dumbbell'],
+      },
+    ]);
+    vi.doMock('$lib/server/movement/wger', () => ({
+      searchWgerExercises,
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      saveWorkoutTemplateServer: vi.fn(),
+      listExerciseCatalogItemsServer: vi.fn(async () => [
+        {
+          id: 'wger:1',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          sourceType: 'wger' as const,
+          externalId: '1',
+          title: 'Goblet squat',
+          muscleGroups: ['Quadriceps'],
+          equipment: ['Dumbbell'],
+          instructions: 'Stand tall and squat deep.',
+        },
+      ]),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { exerciseCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      upsertMirrorRecord: vi.fn(async () => undefined),
+    }));
+
+    const { searchMovementExercisesServer } =
+      await import('../../../../src/lib/server/movement/service.ts');
+
+    await expect(searchMovementExercisesServer('squat')).resolves.toEqual([
+      expect.objectContaining({
+        id: 'wger:1',
+        title: 'Goblet squat',
+      }),
+    ]);
+    expect(searchWgerExercises).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when wger fails and no local cache exists', async () => {
+    const searchWgerExercises = vi.fn(async () => {
+      throw new Error('wger request failed with 500');
+    });
+    const upsertMirrorRecord = vi.fn(async () => undefined);
+
+    vi.doMock('$lib/server/movement/wger', () => ({
+      searchWgerExercises,
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      saveWorkoutTemplateServer: vi.fn(),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { exerciseCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      upsertMirrorRecord,
+    }));
+
+    const { searchMovementExercisesServer } =
+      await import('../../../../src/lib/server/movement/service.ts');
+
+    await expect(searchMovementExercisesServer('goblet squat')).resolves.toEqual([]);
+    expect(upsertMirrorRecord).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when wger returns no matches and the local cache is empty', async () => {
+    const searchWgerExercises = vi.fn(async () => []);
+    const upsertMirrorRecord = vi.fn(async () => undefined);
+
+    vi.doMock('$lib/server/movement/wger', () => ({
+      searchWgerExercises,
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      saveWorkoutTemplateServer: vi.fn(),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { exerciseCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      upsertMirrorRecord,
+    }));
+
+    const { searchMovementExercisesServer } =
+      await import('../../../../src/lib/server/movement/service.ts');
+
+    await expect(searchMovementExercisesServer('goblet squat')).resolves.toEqual([]);
+    expect(searchWgerExercises).toHaveBeenCalledTimes(1);
+    expect(upsertMirrorRecord).not.toHaveBeenCalled();
+  });
+});

--- a/tests/features/unit/movement/wger.test.ts
+++ b/tests/features/unit/movement/wger.test.ts
@@ -22,6 +22,7 @@ describe('wger adapter', () => {
     const results = await searchWgerExercises('squat', fetchImpl as never);
 
     expect(fetchImpl).toHaveBeenCalled();
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
     expect(results).toEqual([
       {
         id: 'wger:123',

--- a/tests/features/unit/nutrition/client.test.ts
+++ b/tests/features/unit/nutrition/client.test.ts
@@ -83,30 +83,27 @@ describe('nutrition client', () => {
   it('looks up packaged barcode hits through a dynamic request client endpoint', async () => {
     const requestSpies = new Map<string, ReturnType<typeof vi.fn>>();
     const createFeatureRequestClient = vi.fn((endpoint: string) => {
-      const request = vi.fn(
-        async () =>
-          ({
-            match: {
-              id: 'off:049000028911',
-              name: 'Diet Cola',
-              calories: 1,
-              protein: 0,
-              fiber: 0,
-              carbs: 0,
-              fat: 0,
-              sourceName: 'Open Food Facts',
-              sourceType: 'open-food-facts' as const,
-              barcode: '049000028911',
-              isEnriched: true,
-            } satisfies FoodLookupResult,
-            notice: 'Packaged food loaded from local cache.',
-            metadata: {
-              provenance: [],
-              cacheStatus: 'local-cache' as const,
-              degradationStatus: 'none' as const,
-            },
-          })
-      );
+      const request = vi.fn(async () => ({
+        match: {
+          id: 'off:049000028911',
+          name: 'Diet Cola',
+          calories: 1,
+          protein: 0,
+          fiber: 0,
+          carbs: 0,
+          fat: 0,
+          sourceName: 'Open Food Facts',
+          sourceType: 'open-food-facts' as const,
+          barcode: '049000028911',
+          isEnriched: true,
+        } satisfies FoodLookupResult,
+        notice: 'Packaged food loaded from local cache.',
+        metadata: {
+          provenance: [],
+          cacheStatus: 'local-cache' as const,
+          degradationStatus: 'none' as const,
+        },
+      }));
       requestSpies.set(endpoint, request);
       return { request };
     });

--- a/tests/features/unit/nutrition/client.test.ts
+++ b/tests/features/unit/nutrition/client.test.ts
@@ -86,18 +86,26 @@ describe('nutrition client', () => {
       const request = vi.fn(
         async () =>
           ({
-            id: 'off:049000028911',
-            name: 'Diet Cola',
-            calories: 1,
-            protein: 0,
-            fiber: 0,
-            carbs: 0,
-            fat: 0,
-            sourceName: 'Open Food Facts',
-            sourceType: 'open-food-facts' as const,
-            barcode: '049000028911',
-            isEnriched: true,
-          }) satisfies FoodLookupResult
+            match: {
+              id: 'off:049000028911',
+              name: 'Diet Cola',
+              calories: 1,
+              protein: 0,
+              fiber: 0,
+              carbs: 0,
+              fat: 0,
+              sourceName: 'Open Food Facts',
+              sourceType: 'open-food-facts' as const,
+              barcode: '049000028911',
+              isEnriched: true,
+            } satisfies FoodLookupResult,
+            notice: 'Packaged food loaded from local cache.',
+            metadata: {
+              provenance: [],
+              cacheStatus: 'local-cache' as const,
+              degradationStatus: 'none' as const,
+            },
+          })
       );
       requestSpies.set(endpoint, request);
       return { request };
@@ -136,4 +144,106 @@ describe('nutrition client', () => {
     });
     expect(next.form.name).toBe('Diet Cola');
   });
+
+  it('does not surface custom local foods as USDA-backed fallback matches in client mode', async () => {
+    const createFeatureRequestClient = vi.fn(() => ({
+      request: vi.fn(async (_input, runFallback) => await runFallback(useFakeDb())),
+    }));
+    const createFeatureActionClient = vi.fn(() => ({
+      action: vi.fn(),
+      stateAction: vi.fn(),
+    }));
+
+    vi.doMock('$lib/core/http/feature-client', () => ({
+      createFeatureActionClient,
+      createFeatureRequestClient,
+    }));
+    vi.doMock('$lib/features/nutrition/store', () => ({
+      listFoodCatalogItems: vi.fn(async () => [
+        {
+          id: 'food-catalog-1',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          name: 'Custom oatmeal bowl',
+          sourceType: 'custom',
+          sourceName: 'Local catalog',
+          calories: 320,
+          protein: 12,
+          fiber: 8,
+          carbs: 52,
+          fat: 7,
+        },
+      ]),
+      listRecipeCatalogItems: vi.fn(async () => []),
+    }));
+
+    const { createNutritionPageState, searchNutritionFoods } =
+      await import('../../../../src/lib/features/nutrition/client.ts');
+
+    const next = await searchNutritionFoods({
+      ...createNutritionPageState(),
+      localDay: '2026-04-03',
+      searchQuery: 'oatmeal',
+    });
+
+    expect(next.matches).toEqual([
+      expect.objectContaining({
+        id: 'fdc-oatmeal',
+        name: 'Oatmeal with berries',
+        sourceName: 'USDA fallback',
+      }),
+    ]);
+    expect(next.matches.find((match) => match.id === 'food-catalog-1')).toBeUndefined();
+  });
+
+  it('does not select custom local barcode hits as packaged-food fallback matches in client mode', async () => {
+    const createFeatureRequestClient = vi.fn(() => ({
+      request: vi.fn(async (_input, runFallback) => await runFallback(useFakeDb())),
+    }));
+    const createFeatureActionClient = vi.fn(() => ({
+      action: vi.fn(),
+      stateAction: vi.fn(),
+    }));
+
+    vi.doMock('$lib/core/http/feature-client', () => ({
+      createFeatureActionClient,
+      createFeatureRequestClient,
+    }));
+    vi.doMock('$lib/features/nutrition/store', () => ({
+      listFoodCatalogItems: vi.fn(async () => [
+        {
+          id: 'food-catalog-1',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          name: 'Custom granola bar',
+          sourceType: 'custom',
+          sourceName: 'Local catalog',
+          barcode: '049000028911',
+          calories: 220,
+          protein: 4,
+          fiber: 3,
+          carbs: 28,
+          fat: 9,
+        },
+      ]),
+      listRecipeCatalogItems: vi.fn(async () => []),
+    }));
+
+    const { createNutritionPageState, lookupPackagedBarcode } =
+      await import('../../../../src/lib/features/nutrition/client.ts');
+
+    const next = await lookupPackagedBarcode({
+      ...createNutritionPageState(),
+      localDay: '2026-04-03',
+      barcodeQuery: '049000028911',
+    });
+
+    expect(next.selectedMatch).toBeNull();
+    expect(next.form.name).toBe('');
+    expect(next.packagedNotice).toBe('Packaged food loaded from local cache.');
+  });
 });
+
+function useFakeDb() {
+  return {} as never;
+}

--- a/tests/features/unit/nutrition/open-food-facts.test.ts
+++ b/tests/features/unit/nutrition/open-food-facts.test.ts
@@ -36,6 +36,28 @@ describe('open food facts adapter', () => {
     });
   });
 
+  it('preserves packaged-food metadata needed for local cache cards', () => {
+    const normalized = normalizeOpenFoodFactsProduct({
+      code: '049000028911',
+      product_name: 'Diet Cola',
+      image_front_small_url: 'https://cdn.test/diet-cola-front.jpg',
+      ingredients_text: 'Carbonated water, natural flavors',
+      nutriments: {
+        'energy-kcal_100g': 1,
+        carbohydrates_100g: 0,
+        fat_100g: 0,
+        proteins_100g: 0,
+        fiber_100g: 0,
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      id: 'off:049000028911',
+      imageUrl: 'https://cdn.test/diet-cola-front.jpg',
+      ingredientsText: 'Carbonated water, natural flavors',
+    });
+  });
+
   it('fetches barcode results and handles misses', async () => {
     const fetchImpl = vi
       .fn<typeof fetch>()
@@ -75,5 +97,6 @@ describe('open food facts adapter', () => {
 
     expect(results).toHaveLength(2);
     expect(fetchImpl.mock.calls[0]?.[0]).toContain('/cgi/search.pl?');
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/tests/features/unit/nutrition/recommend.test.ts
+++ b/tests/features/unit/nutrition/recommend.test.ts
@@ -77,4 +77,38 @@ describe('nutrition recommendations', () => {
     ]);
     expect(recommendation?.score).toBeLessThan(35);
   });
+
+  it('preserves source provenance for recommendation cards', () => {
+    const recommendations = buildNutritionRecommendations({
+      context: {
+        mealType: 'dinner',
+        sleepHours: 7,
+        sleepQuality: 4,
+        anxietyCount: 0,
+        symptomCount: 0,
+      },
+      foods: [],
+      recipes: [
+        {
+          id: 'themealdb:52772',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          title: 'Teriyaki Chicken Bowl',
+          sourceType: 'themealdb',
+          sourceName: 'TheMealDB',
+          externalId: '52772',
+          mealType: 'dinner',
+          cuisine: 'Japanese',
+          ingredients: ['Chicken', 'Soy sauce', 'Rice', 'Broccoli'],
+        },
+      ],
+    });
+
+    expect(recommendations[0]).toMatchObject({
+      title: 'Teriyaki Chicken Bowl',
+      sourceName: 'TheMealDB',
+      sourcePosture: 'optional',
+      canPlanDirectly: false,
+    });
+  });
 });

--- a/tests/features/unit/nutrition/route.test.ts
+++ b/tests/features/unit/nutrition/route.test.ts
@@ -11,8 +11,23 @@ describe('nutrition dynamic routes', () => {
 
   it('returns a cached barcode hit before calling remote enrichment', async () => {
     const lookupNutritionBarcodeServer = vi.fn(async () => ({
-      id: 'off:049000028911',
-      name: 'Diet Cola',
+      match: {
+        id: 'off:049000028911',
+        name: 'Diet Cola',
+      },
+      notice: 'Packaged food loaded from local cache.',
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'open-food-facts',
+            sourceName: 'Open Food Facts',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'none',
+      },
     }));
     vi.doMock('$lib/server/nutrition/service', () => ({
       lookupNutritionBarcodeServer,
@@ -32,10 +47,75 @@ describe('nutrition dynamic routes', () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
-      id: 'off:049000028911',
-      name: 'Diet Cola',
+      match: {
+        id: 'off:049000028911',
+        name: 'Diet Cola',
+      },
+      notice: 'Packaged food loaded from local cache.',
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'open-food-facts',
+            sourceName: 'Open Food Facts',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'none',
+      },
     });
     expect(lookupNutritionBarcodeServer).toHaveBeenCalledWith('049000028911');
+  });
+
+  it('returns a barcode miss envelope unchanged', async () => {
+    const lookupNutritionBarcodeServer = vi.fn(async () => ({
+      match: null,
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'open-food-facts',
+            sourceName: 'Open Food Facts',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    }));
+    vi.doMock('$lib/server/nutrition/service', () => ({
+      lookupNutritionBarcodeServer,
+      enrichNutritionFoodServer: vi.fn(),
+      searchPackagedFoodsServer: vi.fn(),
+      searchUsdaFoodsServer: vi.fn(),
+      searchRecipesServer: vi.fn(),
+    }));
+
+    const { POST } = await import('../../../../src/routes/api/nutrition/barcode/[code]/+server.ts');
+    const response = await POST({
+      request: new Request('http://health.test/api/nutrition/barcode/000', {
+        method: 'POST',
+      }),
+      params: { code: '000' },
+    } as unknown as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      match: null,
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'open-food-facts',
+            sourceName: 'Open Food Facts',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+      },
+    });
   });
 
   it('maps missing USDA API keys to a 503 enrich response', async () => {
@@ -115,6 +195,18 @@ describe('nutrition dynamic routes', () => {
     const searchUsdaFoodsServer = vi.fn(async () => ({
       matches: [{ id: 'fdc-oatmeal', name: 'Oatmeal with berries' }],
       notice: 'USDA live search unavailable, using local fallback foods.',
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'usda-fooddata-central',
+            sourceName: 'USDA FoodData Central',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
+      },
     }));
     vi.doMock('$lib/server/nutrition/service', () => ({
       lookupNutritionBarcodeServer: vi.fn(),
@@ -136,6 +228,18 @@ describe('nutrition dynamic routes', () => {
     expect(await response.json()).toEqual({
       matches: [{ id: 'fdc-oatmeal', name: 'Oatmeal with berries' }],
       notice: 'USDA live search unavailable, using local fallback foods.',
+      metadata: {
+        provenance: [
+          {
+            sourceId: 'usda-fooddata-central',
+            sourceName: 'USDA FoodData Central',
+            category: 'nutrition',
+            productionPosture: 'adopt',
+          },
+        ],
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
+      },
     });
     expect(searchUsdaFoodsServer).toHaveBeenCalledWith('oatmeal');
   });

--- a/tests/features/unit/nutrition/search-service-metadata.test.ts
+++ b/tests/features/unit/nutrition/search-service-metadata.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('nutrition search service metadata', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/server/nutrition/catalog-store');
+    vi.doUnmock('$lib/server/nutrition/open-food-facts');
+    vi.doUnmock('$lib/server/nutrition/themealdb');
+    vi.doUnmock('$lib/server/nutrition/usda');
+    vi.doUnmock('$lib/server/planning/store');
+    vi.doUnmock('$lib/server/db/drizzle/client');
+    vi.doUnmock('$lib/server/db/drizzle/schema');
+    vi.doUnmock('$lib/server/db/drizzle/mirror');
+    vi.restoreAllMocks();
+    vi.resetModules();
+    delete process.env.USDA_FDC_API_KEY;
+    delete process.env.FDC_API_KEY;
+  });
+
+  it('returns degraded packaged-search metadata when Open Food Facts fails and local cache serves the result', async () => {
+    vi.doMock('$lib/server/nutrition/catalog-store', () => ({
+      upsertFoodCatalogItemServer: vi.fn(async (item) => item),
+      upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
+    }));
+    vi.doMock('$lib/server/nutrition/open-food-facts', () => ({
+      fetchOpenFoodFactsProductByBarcode: vi.fn(async () => null),
+      normalizeOpenFoodFactsBarcode: vi.fn((code: string) => code.replace(/\D+/g, '')),
+      normalizeOpenFoodFactsProduct: vi.fn(),
+      searchOpenFoodFactsProducts: vi.fn(async () => {
+        throw new Error('Open Food Facts request failed with 500');
+      }),
+    }));
+    vi.doMock('$lib/server/nutrition/themealdb', () => ({
+      searchThemealdbRecipes: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail: vi.fn(),
+      normalizeUsdaFoodDetail: vi.fn(),
+      searchUsdaFoods: vi.fn(),
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listFoodCatalogItemsServer: vi.fn(async () => [
+        {
+          id: 'off:049000028911',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          name: 'Diet Cola',
+          sourceType: 'open-food-facts',
+          sourceName: 'Open Food Facts',
+          brandName: 'Acme Drinks',
+          barcode: '049000028911',
+          calories: 1,
+          protein: 0,
+          fiber: 0,
+          carbs: 0,
+          fat: 0,
+        },
+      ]),
+      listRecipeCatalogItemsServer: vi.fn(async () => []),
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { foodCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectMirrorRecordById: vi.fn(async () => null),
+    }));
+
+    const { searchPackagedFoodsServer } =
+      await import('../../../../src/lib/server/nutrition/search-service.ts');
+
+    await expect(searchPackagedFoodsServer('cola')).resolves.toMatchObject({
+      matches: [
+        expect.objectContaining({
+          id: 'off:049000028911',
+          name: 'Diet Cola',
+        }),
+      ],
+      notice: 'Open Food Facts search unavailable, using local packaged foods.',
+      metadata: {
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
+        provenance: [
+          expect.objectContaining({
+            sourceId: 'open-food-facts',
+            sourceName: 'Open Food Facts',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('returns local-cache barcode metadata and skips remote lookup when a local packaged food exists', async () => {
+    const fetchOpenFoodFactsProductByBarcode = vi.fn(async () => null);
+
+    vi.doMock('$lib/server/nutrition/catalog-store', () => ({
+      upsertFoodCatalogItemServer: vi.fn(async (item) => item),
+      upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
+    }));
+    vi.doMock('$lib/server/nutrition/open-food-facts', () => ({
+      fetchOpenFoodFactsProductByBarcode,
+      normalizeOpenFoodFactsBarcode: vi.fn((code: string) => code.replace(/\D+/g, '')),
+      normalizeOpenFoodFactsProduct: vi.fn(),
+      searchOpenFoodFactsProducts: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/themealdb', () => ({
+      searchThemealdbRecipes: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail: vi.fn(),
+      normalizeUsdaFoodDetail: vi.fn(),
+      searchUsdaFoods: vi.fn(),
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listFoodCatalogItemsServer: vi.fn(async () => [
+        {
+          id: 'off:049000028911',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          name: 'Diet Cola',
+          sourceType: 'open-food-facts',
+          sourceName: 'Open Food Facts',
+          brandName: 'Acme Drinks',
+          barcode: '049000028911',
+          calories: 1,
+          protein: 0,
+          fiber: 0,
+          carbs: 0,
+          fat: 0,
+        },
+      ]),
+      listRecipeCatalogItemsServer: vi.fn(async () => []),
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { foodCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectMirrorRecordById: vi.fn(async () => null),
+    }));
+
+    const { lookupNutritionBarcodeServer } =
+      await import('../../../../src/lib/server/nutrition/search-service.ts');
+
+    await expect(lookupNutritionBarcodeServer('049000028911')).resolves.toMatchObject({
+      match: expect.objectContaining({
+        id: 'off:049000028911',
+        name: 'Diet Cola',
+      }),
+      notice: 'Packaged food loaded from local cache.',
+      metadata: {
+        cacheStatus: 'local-cache',
+        degradationStatus: 'none',
+        provenance: [
+          expect.objectContaining({
+            sourceId: 'open-food-facts',
+          }),
+        ],
+      },
+    });
+    expect(fetchOpenFoodFactsProductByBarcode).not.toHaveBeenCalled();
+  });
+
+  it('returns USDA fallback metadata when no USDA key is configured', async () => {
+    vi.doMock('$lib/server/nutrition/catalog-store', () => ({
+      upsertFoodCatalogItemServer: vi.fn(async (item) => item),
+      upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
+    }));
+    vi.doMock('$lib/server/nutrition/open-food-facts', () => ({
+      fetchOpenFoodFactsProductByBarcode: vi.fn(async () => null),
+      normalizeOpenFoodFactsBarcode: vi.fn((code: string) => code.replace(/\D+/g, '')),
+      normalizeOpenFoodFactsProduct: vi.fn(),
+      searchOpenFoodFactsProducts: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/themealdb', () => ({
+      searchThemealdbRecipes: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail: vi.fn(),
+      normalizeUsdaFoodDetail: vi.fn(),
+      searchUsdaFoods: vi.fn(),
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listFoodCatalogItemsServer: vi.fn(async () => []),
+      listRecipeCatalogItemsServer: vi.fn(async () => []),
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { foodCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectMirrorRecordById: vi.fn(async () => null),
+    }));
+
+    const { searchUsdaFoodsServer } =
+      await import('../../../../src/lib/server/nutrition/search-service.ts');
+
+    await expect(searchUsdaFoodsServer('oatmeal')).resolves.toMatchObject({
+      matches: expect.any(Array),
+      notice: 'USDA live search unavailable, using local fallback foods.',
+      metadata: {
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
+        provenance: [
+          expect.objectContaining({
+            sourceId: 'usda-fooddata-central',
+            sourceName: 'USDA FoodData Central',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('does not surface custom local foods as USDA-backed local cache matches', async () => {
+    vi.doMock('$lib/server/nutrition/catalog-store', () => ({
+      upsertFoodCatalogItemServer: vi.fn(async (item) => item),
+      upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
+    }));
+    vi.doMock('$lib/server/nutrition/open-food-facts', () => ({
+      fetchOpenFoodFactsProductByBarcode: vi.fn(async () => null),
+      normalizeOpenFoodFactsBarcode: vi.fn((code: string) => code.replace(/\D+/g, '')),
+      normalizeOpenFoodFactsProduct: vi.fn(),
+      searchOpenFoodFactsProducts: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/themealdb', () => ({
+      searchThemealdbRecipes: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail: vi.fn(),
+      normalizeUsdaFoodDetail: vi.fn(),
+      searchUsdaFoods: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listFoodCatalogItemsServer: vi.fn(async () => [
+        {
+          id: 'food-catalog-1',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          name: 'Custom oatmeal bowl',
+          sourceType: 'custom',
+          sourceName: 'Local catalog',
+          calories: 320,
+          protein: 12,
+          fiber: 8,
+          carbs: 52,
+          fat: 7,
+        },
+      ]),
+      listRecipeCatalogItemsServer: vi.fn(async () => []),
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { foodCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectMirrorRecordById: vi.fn(async () => null),
+    }));
+
+    const { searchUsdaFoodsServer } =
+      await import('../../../../src/lib/server/nutrition/search-service.ts');
+
+    await expect(searchUsdaFoodsServer('oatmeal')).resolves.toMatchObject({
+      matches: [
+        expect.objectContaining({
+          id: 'fdc-oatmeal',
+          name: 'Oatmeal with berries',
+          sourceName: 'USDA fallback',
+        }),
+      ],
+      notice: 'USDA live search unavailable, using local fallback foods.',
+      metadata: {
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
+        provenance: [
+          expect.objectContaining({
+            sourceId: 'usda-fooddata-central',
+          }),
+        ],
+      },
+    });
+  });
+
+  it('does not treat a custom local barcode hit as an Open Food Facts cached match', async () => {
+    const fetchOpenFoodFactsProductByBarcode = vi.fn(async () => null);
+
+    vi.doMock('$lib/server/nutrition/catalog-store', () => ({
+      upsertFoodCatalogItemServer: vi.fn(async (item) => item),
+      upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
+    }));
+    vi.doMock('$lib/server/nutrition/open-food-facts', () => ({
+      fetchOpenFoodFactsProductByBarcode,
+      normalizeOpenFoodFactsBarcode: vi.fn((code: string) => code.replace(/\D+/g, '')),
+      normalizeOpenFoodFactsProduct: vi.fn(),
+      searchOpenFoodFactsProducts: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/themealdb', () => ({
+      searchThemealdbRecipes: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail: vi.fn(),
+      normalizeUsdaFoodDetail: vi.fn(),
+      searchUsdaFoods: vi.fn(),
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listFoodCatalogItemsServer: vi.fn(async () => [
+        {
+          id: 'food-catalog-1',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          updatedAt: '2026-04-03T00:00:00.000Z',
+          name: 'Custom granola bar',
+          sourceType: 'custom',
+          sourceName: 'Local catalog',
+          barcode: '049000028911',
+          calories: 220,
+          protein: 4,
+          fiber: 3,
+          carbs: 28,
+          fat: 9,
+        },
+      ]),
+      listRecipeCatalogItemsServer: vi.fn(async () => []),
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { foodCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectMirrorRecordById: vi.fn(async () => null),
+    }));
+
+    const { lookupNutritionBarcodeServer } =
+      await import('../../../../src/lib/server/nutrition/search-service.ts');
+
+    await expect(lookupNutritionBarcodeServer('049000028911')).resolves.toMatchObject({
+      match: null,
+      metadata: {
+        cacheStatus: 'none',
+        degradationStatus: 'none',
+        provenance: [
+          expect.objectContaining({
+            sourceId: 'open-food-facts',
+          }),
+        ],
+      },
+    });
+    expect(fetchOpenFoodFactsProductByBarcode).toHaveBeenCalledWith('049000028911');
+  });
+});

--- a/tests/features/unit/nutrition/search-service.test.ts
+++ b/tests/features/unit/nutrition/search-service.test.ts
@@ -132,16 +132,23 @@ describe('nutrition search service', () => {
     const { searchPackagedFoodsServer } =
       await import('../../../../src/lib/server/nutrition/search-service.ts');
 
-    await expect(searchPackagedFoodsServer('cola')).resolves.toEqual([
-      expect.objectContaining({
-        id: 'off:049000028911',
-        name: 'Diet Cola',
-        brandName: 'Acme Drinks',
+    await expect(searchPackagedFoodsServer('cola')).resolves.toEqual({
+      matches: [
+        expect.objectContaining({
+          id: 'off:049000028911',
+          name: 'Diet Cola',
+          brandName: 'Acme Drinks',
+        }),
+      ],
+      notice: 'Open Food Facts search unavailable, using local packaged foods.',
+      metadata: expect.objectContaining({
+        cacheStatus: 'local-cache',
+        degradationStatus: 'degraded',
       }),
-    ]);
+    });
   });
 
-  it('returns null for barcode lookup when Open Food Facts lookup fails and no local item exists', async () => {
+  it('returns structured null barcode metadata when Open Food Facts lookup fails and no local item exists', async () => {
     vi.doMock('$lib/server/nutrition/catalog-store', () => ({
       upsertFoodCatalogItemServer: vi.fn(async (item) => item),
       upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
@@ -181,6 +188,129 @@ describe('nutrition search service', () => {
     const { lookupNutritionBarcodeServer } =
       await import('../../../../src/lib/server/nutrition/search-service.ts');
 
-    await expect(lookupNutritionBarcodeServer('049000028911')).resolves.toBeNull();
+    await expect(lookupNutritionBarcodeServer('049000028911')).resolves.toEqual({
+      match: null,
+      metadata: expect.objectContaining({
+        cacheStatus: 'none',
+        degradationStatus: 'degraded',
+      }),
+    });
+  });
+
+  it('marks packaged searches as remote-live when a normalized remote product is cached', async () => {
+    vi.doMock('$lib/server/nutrition/catalog-store', () => ({
+      upsertFoodCatalogItemServer: vi.fn(async (item) => ({
+        ...item,
+        id: 'off:049000028911',
+      })),
+      upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
+    }));
+    vi.doMock('$lib/server/nutrition/open-food-facts', () => ({
+      fetchOpenFoodFactsProductByBarcode: vi.fn(async () => null),
+      normalizeOpenFoodFactsBarcode: vi.fn((code: string) => code.replace(/\D+/g, '')),
+      normalizeOpenFoodFactsProduct: vi.fn(() => ({
+        id: 'off:049000028911',
+        createdAt: '2026-04-03T00:00:00.000Z',
+        updatedAt: '2026-04-03T00:00:00.000Z',
+        name: 'Diet Cola',
+        sourceType: 'open-food-facts',
+        sourceName: 'Open Food Facts',
+        brandName: 'Acme Drinks',
+        barcode: '049000028911',
+        calories: 1,
+        protein: 0,
+        fiber: 0,
+        carbs: 0,
+        fat: 0,
+      })),
+      searchOpenFoodFactsProducts: vi.fn(async () => [{ code: '049000028911' }]),
+    }));
+    vi.doMock('$lib/server/nutrition/themealdb', () => ({
+      searchThemealdbRecipes: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail: vi.fn(),
+      normalizeUsdaFoodDetail: vi.fn(),
+      searchUsdaFoods: vi.fn(),
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listFoodCatalogItemsServer: vi.fn(async () => []),
+      listRecipeCatalogItemsServer: vi.fn(async () => []),
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { foodCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectMirrorRecordById: vi.fn(async () => null),
+    }));
+
+    const { searchPackagedFoodsServer } =
+      await import('../../../../src/lib/server/nutrition/search-service.ts');
+
+    await expect(searchPackagedFoodsServer('cola')).resolves.toEqual({
+      matches: [
+        expect.objectContaining({
+          id: 'off:049000028911',
+          name: 'Diet Cola',
+          brandName: 'Acme Drinks',
+        }),
+      ],
+      metadata: expect.objectContaining({
+        cacheStatus: 'remote-live',
+        degradationStatus: 'none',
+      }),
+    });
+  });
+
+  it('returns a degraded null barcode envelope when the remote product cannot be normalized', async () => {
+    vi.doMock('$lib/server/nutrition/catalog-store', () => ({
+      upsertFoodCatalogItemServer: vi.fn(async (item) => item),
+      upsertRecipeCatalogItemServer: vi.fn(async (recipe) => recipe),
+    }));
+    vi.doMock('$lib/server/nutrition/open-food-facts', () => ({
+      fetchOpenFoodFactsProductByBarcode: vi.fn(async () => ({ code: '049000028911' })),
+      normalizeOpenFoodFactsBarcode: vi.fn((code: string) => code.replace(/\D+/g, '')),
+      normalizeOpenFoodFactsProduct: vi.fn(() => null),
+      searchOpenFoodFactsProducts: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/themealdb', () => ({
+      searchThemealdbRecipes: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/nutrition/usda', () => ({
+      fetchUsdaFoodDetail: vi.fn(),
+      normalizeUsdaFoodDetail: vi.fn(),
+      searchUsdaFoods: vi.fn(),
+    }));
+    vi.doMock('$lib/server/planning/store', () => ({
+      listFoodCatalogItemsServer: vi.fn(async () => []),
+      listRecipeCatalogItemsServer: vi.fn(async () => []),
+      listWorkoutTemplatesServer: vi.fn(async () => []),
+      listExerciseCatalogItemsServer: vi.fn(async () => []),
+    }));
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/schema', () => ({
+      drizzleSchema: { foodCatalogItems: {} },
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectMirrorRecordById: vi.fn(async () => null),
+    }));
+
+    const { lookupNutritionBarcodeServer } =
+      await import('../../../../src/lib/server/nutrition/search-service.ts');
+
+    await expect(lookupNutritionBarcodeServer('049000028911')).resolves.toEqual({
+      match: null,
+      metadata: expect.objectContaining({
+        cacheStatus: 'none',
+        degradationStatus: 'degraded',
+      }),
+    });
   });
 });

--- a/tests/features/unit/nutrition/usda.test.ts
+++ b/tests/features/unit/nutrition/usda.test.ts
@@ -67,5 +67,7 @@ describe('usda adapter', () => {
     expect(results[0]?.externalId).toBe('12345');
     expect(detail.fdcId).toBe(12345);
     expect(fetchImpl.mock.calls[0]?.[1]?.method).toBe('POST');
+    expect(fetchImpl.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchImpl.mock.calls[1]?.[1]?.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/tests/features/unit/review/model.test.ts
+++ b/tests/features/unit/review/model.test.ts
@@ -275,15 +275,13 @@ describe('review model', () => {
       healthReferenceLinks: [
         {
           label: 'Metformin 500 MG Oral Tablet',
-          href:
-            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+          href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
         },
       ],
       symptomReferenceLinks: [
         {
           label: 'Headache',
-          href:
-            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+          href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
         },
       ],
       healthHighlights: ['Low sleep lined up with higher anxiety on 2026-04-02.'],
@@ -313,15 +311,13 @@ describe('review model', () => {
         kind: 'medication',
         categoryLabel: 'Medication',
         label: 'Metformin 500 MG Oral Tablet',
-        href:
-          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+        href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
       },
       {
         kind: 'symptom',
         categoryLabel: 'Symptom',
         label: 'Headache',
-        href:
-          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+        href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
       },
     ]);
     expect(createReviewSections(weekly).map((section) => section.title)).toContain(

--- a/tests/features/unit/review/model.test.ts
+++ b/tests/features/unit/review/model.test.ts
@@ -97,6 +97,8 @@ describe('review model', () => {
       ],
       deviceHighlights: ['Sleep duration: 8 hours on 2026-04-02'],
       assessmentSummary: ['WHO-5: Strong wellbeing (17)'],
+      healthReferenceLinks: [],
+      symptomReferenceLinks: [],
       healthHighlights: [],
       contextSignals: ['Low sleep and a written reflection both landed on 2026-04-02.'],
       contextCaptureLinkedEventIds: ['anxiety-1'],
@@ -161,6 +163,7 @@ describe('review model', () => {
       'Drift flags',
       'Assessment changes',
       'Health highlights',
+      'Health references',
       'Context signals',
       'Journal excerpts',
       'Patterns to watch',
@@ -269,6 +272,20 @@ describe('review model', () => {
       grocerySignals: [],
       deviceHighlights: [],
       assessmentSummary: [],
+      healthReferenceLinks: [
+        {
+          label: 'Metformin 500 MG Oral Tablet',
+          href:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+        },
+      ],
+      symptomReferenceLinks: [
+        {
+          label: 'Headache',
+          href:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+        },
+      ],
       healthHighlights: ['Low sleep lined up with higher anxiety on 2026-04-02.'],
       contextSignals: ['Low sleep and a written reflection both landed on 2026-04-02.'],
       contextCaptureLinkedEventIds: ['anxiety-1'],
@@ -287,6 +304,27 @@ describe('review model', () => {
       'Health highlights'
     );
     expect(createReviewSections(weekly).map((section) => section.title)).toContain(
+      'Health references'
+    );
+    expect(
+      createReviewSections(weekly).find((section) => section.title === 'Health references')?.items
+    ).toEqual([
+      {
+        kind: 'medication',
+        categoryLabel: 'Medication',
+        label: 'Metformin 500 MG Oral Tablet',
+        href:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+      },
+      {
+        kind: 'symptom',
+        categoryLabel: 'Symptom',
+        label: 'Headache',
+        href:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+      },
+    ]);
+    expect(createReviewSections(weekly).map((section) => section.title)).toContain(
       'Context signals'
     );
     expect(createReviewSections(weekly).map((section) => section.title)).toContain(
@@ -295,6 +333,104 @@ describe('review model', () => {
     expect(createReviewSections(weekly).map((section) => section.title)).toContain(
       'Patterns to watch'
     );
+  });
+
+  it('marks pending adherence as pending and adds journal intent actions only when context exists', () => {
+    const weekly: WeeklyReviewData = {
+      anchorDay: '2026-04-02',
+      snapshot: {
+        id: 'review:2026-03-31',
+        createdAt: '2026-04-02T08:00:00.000Z',
+        updatedAt: '2026-04-02T08:00:00.000Z',
+        weekStart: '2026-03-31',
+        headline: 'Mindful reset',
+        daysTracked: 1,
+        flags: [],
+        correlations: [],
+        experiment: undefined,
+      },
+      averageMood: 4,
+      averageSleep: 7,
+      averageProtein: 25,
+      sobrietyStreak: 0,
+      nutritionHighlights: [],
+      nutritionStrategy: [],
+      planningHighlights: [],
+      adherenceScores: [
+        {
+          label: 'Overall',
+          score: 0,
+          completed: 0,
+          missed: 0,
+          pending: 2,
+          inferredCount: 0,
+          tone: 'mixed',
+          detail: '2 items still pending',
+        },
+      ],
+      adherenceSignals: [],
+      adherenceMatches: [
+        {
+          id: 'adherence-pending',
+          createdAt: '2026-04-02T08:00:00.000Z',
+          updatedAt: '2026-04-02T08:00:00.000Z',
+          weekStart: '2026-03-31',
+          planSlotId: 'slot-1',
+          localDay: '2026-04-02',
+          slotType: 'meal',
+          slotTitle: 'Greek yogurt bowl',
+          outcome: 'pending',
+          matchSource: 'food-entry',
+          matchedRecordId: undefined,
+          confidence: 'explicit',
+          reason: 'still queued for later today',
+          fingerprint: 'fp-pending',
+        },
+      ],
+      grocerySignals: [],
+      deviceHighlights: [],
+      assessmentSummary: [],
+      healthReferenceLinks: [],
+      symptomReferenceLinks: [],
+      healthHighlights: [],
+      contextSignals: ['Low sleep and a written reflection both landed on 2026-04-02.'],
+      contextCaptureLinkedEventIds: ['anxiety-1'],
+      journalHighlights: [
+        'Evening review on 2026-04-02: Crowded store and headache drained the afternoon.',
+      ],
+      journalReflectionLinkedEventIds: ['anxiety-1'],
+      patternHighlights: [],
+      whatChangedHighlights: [],
+      weeklyRecommendation: null,
+      weeklyDecisionCards: [],
+      experimentOptions: [],
+    };
+
+    expect(createReviewAdherenceCards(weekly)).toEqual([
+      {
+        label: 'Overall',
+        value: 'Pending',
+        detail: '2 items still pending.',
+        tone: 'mixed',
+      },
+    ]);
+    expect(createReviewAdherenceAuditItems(weekly)).toEqual([]);
+
+    const contextSection = createReviewSections(weekly).find(
+      (section) => section.title === 'Context signals'
+    );
+    const journalSection = createReviewSections(weekly).find(
+      (section) => section.title === 'Journal excerpts'
+    );
+
+    expect(contextSection).toMatchObject({
+      actionLabel: 'Capture context note',
+    });
+    expect(contextSection?.actionHref).toMatch(/^\/journal\?intentId=/);
+    expect(journalSection).toMatchObject({
+      actionLabel: 'Write reflection',
+    });
+    expect(journalSection?.actionHref).toMatch(/^\/journal\?intentId=/);
   });
 
   it('maps plan fallback recommendations into a stable page view', () => {
@@ -326,6 +462,8 @@ describe('review model', () => {
       ],
       deviceHighlights: [],
       assessmentSummary: [],
+      healthReferenceLinks: [],
+      symptomReferenceLinks: [],
       healthHighlights: [],
       contextSignals: [],
       contextCaptureLinkedEventIds: [],
@@ -394,6 +532,8 @@ describe('review model', () => {
       grocerySignals: [],
       deviceHighlights: [],
       assessmentSummary: [],
+      healthReferenceLinks: [],
+      symptomReferenceLinks: [],
       healthHighlights: ['Low sleep lined up with higher anxiety on 2026-04-02.'],
       contextSignals: ['Low sleep and a written reflection both landed on 2026-04-02.'],
       contextCaptureLinkedEventIds: ['anxiety-1'],

--- a/tests/features/unit/review/service.test.ts
+++ b/tests/features/unit/review/service.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { saveAssessmentProgress, submitAssessment } from '$lib/features/assessments/service';
 import { deriveWeeklyGroceries, setGroceryItemState } from '$lib/features/groceries/service';
-import { logAnxietyEvent, logSymptomEvent } from '$lib/features/health/service';
+import {
+  logAnxietyEvent,
+  logSymptomEvent,
+  quickLogHealthTemplate,
+  saveHealthTemplate,
+} from '$lib/features/health/service';
 import { commitImportBatch, previewImport } from '$lib/features/imports/store';
 import { saveJournalEntry } from '$lib/features/journal/service';
 import {
@@ -100,11 +105,14 @@ describe('review service', () => {
       instrument: 'WHO-5',
       itemResponses: [3, 3, 3, 4, 4],
     });
-    const batch = await previewImport(db, {
+    await previewImport(db, {
       sourceType: 'healthkit-companion',
       rawText: HEALTHKIT_BUNDLE_JSON,
     });
-    await commitImportBatch(db, batch.id);
+    await commitImportBatch(db, {
+      sourceType: 'healthkit-companion',
+      rawText: HEALTHKIT_BUNDLE_JSON,
+    });
   }
 
   it('computes weekly trend comparisons', async () => {
@@ -281,6 +289,81 @@ describe('review service', () => {
     expect(weekly.journalHighlights).toContain(
       'Evening review on 2026-03-30: Crowded store and headache drained the afternoon.'
     );
+  });
+
+  it('collects medication reference links from quick-logged health events into the weekly snapshot', async () => {
+    const db = getDb();
+    await seedWeek();
+
+    const metformin = await saveHealthTemplate(db, {
+      label: 'Metformin 500 MG Oral Tablet',
+      templateType: 'medication',
+      defaultDose: 1,
+      defaultUnit: 'tablet',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+    });
+    const vitaminD = await saveHealthTemplate(db, {
+      label: 'Vitamin D3',
+      templateType: 'supplement',
+      defaultDose: 1,
+      defaultUnit: 'capsule',
+      referenceUrl: 'https://example.com/supplement-reference',
+    });
+
+    await quickLogHealthTemplate(db, {
+      localDay: '2026-04-02',
+      templateId: metformin.id,
+    });
+    await quickLogHealthTemplate(db, {
+      localDay: '2026-04-01',
+      templateId: metformin.id,
+    });
+    await quickLogHealthTemplate(db, {
+      localDay: '2026-04-02',
+      templateId: vitaminD.id,
+    });
+
+    const weekly = await buildWeeklySnapshot(db, '2026-04-02');
+
+    expect(weekly.healthReferenceLinks).toEqual([
+      {
+        label: 'Metformin 500 MG Oral Tablet',
+        href:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+      },
+    ]);
+  });
+
+  it('collects symptom reference links from logged symptom events into the weekly snapshot', async () => {
+    const db = getDb();
+    await seedWeek();
+
+    await logSymptomEvent(db, {
+      localDay: '2026-04-02',
+      symptom: 'Headache',
+      severity: 4,
+      note: 'After lunch',
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+    });
+    await logSymptomEvent(db, {
+      localDay: '2026-04-01',
+      symptom: 'Headache',
+      severity: 3,
+      referenceUrl:
+        'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+    });
+
+    const weekly = await buildWeeklySnapshot(db, '2026-04-02');
+
+    expect(weekly.symptomReferenceLinks).toEqual([
+      {
+        label: 'Headache',
+        href:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+      },
+    ]);
   });
 
   it('captures repeated journal-linked patterns in the weekly snapshot', async () => {

--- a/tests/features/unit/review/service.test.ts
+++ b/tests/features/unit/review/service.test.ts
@@ -329,8 +329,7 @@ describe('review service', () => {
     expect(weekly.healthReferenceLinks).toEqual([
       {
         label: 'Metformin 500 MG Oral Tablet',
-        href:
-          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
+        href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.c=860975&mainSearchCriteria.v.dn=Metformin+500+MG+Oral+Tablet&informationRecipient.languageCode.c=en',
       },
     ]);
   });
@@ -360,8 +359,7 @@ describe('review service', () => {
     expect(weekly.symptomReferenceLinks).toEqual([
       {
         label: 'Headache',
-        href:
-          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+        href: 'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
       },
     ]);
   });

--- a/tests/features/unit/timeline/controller.test.ts
+++ b/tests/features/unit/timeline/controller.test.ts
@@ -13,11 +13,14 @@ describe('timeline controller', () => {
 
   it('loads timeline controller state from imported events', async () => {
     const db = getDb();
-    const batch = await previewImport(db, {
+    await previewImport(db, {
       sourceType: 'healthkit-companion',
       rawText: HEALTHKIT_BUNDLE_JSON,
     });
-    await commitImportBatch(db, batch.id);
+    await commitImportBatch(db, {
+      sourceType: 'healthkit-companion',
+      rawText: HEALTHKIT_BUNDLE_JSON,
+    });
 
     let state = setTimelineFilter(createTimelinePageState(), 'native-companion');
     state = await loadTimelinePage(db, state);

--- a/tests/features/unit/timeline/route.test.ts
+++ b/tests/features/unit/timeline/route.test.ts
@@ -56,6 +56,45 @@ describe('timeline route', () => {
     expect(loadTimelinePageServer).toHaveBeenCalledWith(state);
   });
 
+  it('accepts timeline items that carry a reference url from the server path', async () => {
+    const state = { loading: true, filter: 'all', items: [] };
+    const loadTimelinePageServer = vi.fn(async () => ({
+      ...state,
+      loading: false,
+      items: [
+        {
+          event: { sourceType: 'manual' },
+          label: 'Symptom',
+          valueLabel: '4',
+          sourceLabel: 'Manual',
+          referenceUrl:
+            'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+        },
+      ],
+    }));
+    const { POST } = await importRoute({ loadTimelinePageServer });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/timeline', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'load', state }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            label: 'Symptom',
+            referenceUrl:
+              'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+          }),
+        ],
+      })
+    );
+  });
+
   it('returns 400 for invalid timeline payloads', async () => {
     const { POST } = await importRoute({});
     const missingState = await POST({

--- a/tests/features/unit/timeline/server.service.test.ts
+++ b/tests/features/unit/timeline/server.service.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('timeline server service', () => {
+  afterEach(() => {
+    vi.doUnmock('$lib/server/db/drizzle/client');
+    vi.doUnmock('$lib/server/db/drizzle/mirror');
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('preserves reference urls when loading timeline items from the server mirror', async () => {
+    vi.doMock('$lib/server/db/drizzle/client', () => ({
+      getServerDrizzleClient: () => ({ db: { mocked: true } }),
+    }));
+    vi.doMock('$lib/server/db/drizzle/mirror', () => ({
+      selectAllMirrorRecords: vi.fn(async () => [
+        {
+          id: 'symptom-headache',
+          createdAt: '2026-04-02T12:00:00Z',
+          updatedAt: '2026-04-02T12:00:00Z',
+          sourceType: 'manual',
+          sourceApp: 'personal-health-cockpit',
+          sourceTimestamp: '2026-04-02T12:00:00Z',
+          localDay: '2026-04-02',
+          confidence: 1,
+          eventType: 'symptom',
+          value: 4,
+          payload: {
+            kind: 'symptom',
+            symptom: 'Headache',
+            severity: 4,
+            referenceUrl:
+              'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+          },
+        },
+      ]),
+    }));
+
+    const service = await import('../../../../src/lib/server/timeline/service.ts');
+    const result = await service.listTimelineEventsServer();
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        label: 'Symptom',
+        referenceUrl:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+      }),
+    ]);
+  });
+});

--- a/tests/features/unit/timeline/service.test.ts
+++ b/tests/features/unit/timeline/service.test.ts
@@ -150,4 +150,5 @@ describe('timeline service', () => {
     expect(items[0]?.event.id).toBe('native-sleep');
     expect(items[0]?.valueLabel).toBe('8 hours');
   });
+
 });

--- a/tests/features/unit/timeline/service.test.ts
+++ b/tests/features/unit/timeline/service.test.ts
@@ -150,5 +150,4 @@ describe('timeline service', () => {
     expect(items[0]?.event.id).toBe('native-sleep');
     expect(items[0]?.valueLabel).toBe('8 hours');
   });
-
 });

--- a/tests/features/unit/today/intelligence.test.ts
+++ b/tests/features/unit/today/intelligence.test.ts
@@ -144,6 +144,64 @@ describe('today intelligence', () => {
     expect(result.primaryRecommendation?.provenance).not.toHaveLength(0);
   });
 
+  it('keeps health-event provenance rows text-only even when the driving event has a reference url', () => {
+    const result = buildTodayIntelligence(
+      createBaseInput({
+        dailyRecord: {
+          id: 'daily:2026-04-02',
+          createdAt: '2026-04-02T08:00:00.000Z',
+          updatedAt: '2026-04-02T08:00:00.000Z',
+          date: '2026-04-02',
+          mood: 3,
+          energy: 2,
+          stress: 4,
+          focus: 3,
+          sleepHours: 5.5,
+          sleepQuality: 2,
+          freeformNote: 'Dragging today.',
+        },
+        recoveryAdaptation: {
+          level: 'recovery',
+          headline: 'Recovery mode: simplify the day.',
+          reasons: ['Sleep landed under 6 hours.'],
+          mealFallback: [],
+          workoutFallback: [],
+          mealRecommendation: null,
+          workoutRecommendation: null,
+          actions: [],
+        },
+        events: [
+          {
+            id: 'symptom-1',
+            createdAt: '2026-04-02T09:00:00.000Z',
+            updatedAt: '2026-04-02T09:00:00.000Z',
+            sourceType: 'manual',
+            sourceApp: 'personal-health-cockpit',
+            localDay: '2026-04-02',
+            confidence: 1,
+            eventType: 'symptom',
+            value: 4,
+            payload: {
+              symptom: 'Headache',
+              severity: 4,
+              referenceUrl:
+                'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+            },
+          },
+        ],
+      })
+    );
+
+    expect(result.primaryRecommendation?.provenance).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceKind: 'health_event',
+          label: 'Symptom: 4, manual',
+        }),
+      ])
+    );
+  });
+
   it('prefers the planned workout when the day is calm and both meal and workout are queued', () => {
     const result = buildTodayIntelligence(
       createBaseInput({

--- a/tests/features/unit/today/model.test.ts
+++ b/tests/features/unit/today/model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { TodaySnapshot } from '$lib/features/today/snapshot';
 import {
   createDailyCheckinPayload,
+  createTodayEventRows,
   createTodayNutritionGuidance,
   createTodayNutritionPulseMetrics,
   createPlannedMealProjectionRows,
@@ -90,6 +91,61 @@ describe('today model', () => {
       mood: 4,
       focus: 5,
     });
+  });
+
+  it('carries reference links into today event rows for same-day health events', () => {
+    const snapshot: TodaySnapshot = {
+      date: '2026-04-02',
+      dailyRecord: null,
+      foodEntries: [],
+      nutritionSummary: {
+        calories: 0,
+        protein: 0,
+        fiber: 0,
+        carbs: 0,
+        fat: 0,
+      },
+      plannedMeal: null,
+      plannedMealIssue: null,
+      plannedWorkout: null,
+      plannedWorkoutIssue: null,
+      recoveryAdaptation: null,
+      intelligence: {
+        primaryRecommendation: null,
+        fallbackState: null,
+      },
+      planItems: [],
+      events: [
+        {
+          id: 'symptom-headache',
+          createdAt: '2026-04-02T12:00:00Z',
+          updatedAt: '2026-04-02T12:00:00Z',
+          sourceType: 'manual',
+          sourceApp: 'personal-health-cockpit',
+          sourceTimestamp: '2026-04-02T12:00:00Z',
+          localDay: '2026-04-02',
+          confidence: 1,
+          eventType: 'symptom',
+          value: 4,
+          payload: {
+            kind: 'symptom',
+            symptom: 'Headache',
+            severity: 4,
+            referenceUrl:
+              'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+          },
+        },
+      ],
+      latestJournalEntry: null,
+    };
+
+    expect(createTodayEventRows(snapshot)).toEqual([
+      expect.objectContaining({
+        label: 'Symptom',
+        referenceUrl:
+          'https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.90&mainSearchCriteria.v.c=R51&mainSearchCriteria.v.dn=Headache&informationRecipient.languageCode.c=en',
+      }),
+    ]);
   });
 
   it('builds recommendation support rows from plan, nutrition, and recovery context', () => {
@@ -366,5 +422,70 @@ describe('today model', () => {
         },
       })
     ).toContain('Nutrition: protein 24g so far; fiber pace is unknown.');
+  });
+
+  it('keeps mixed known and unknown planned-meal projections truthful when a planned meal exists', () => {
+    const snapshot: TodaySnapshot = {
+      date: '2026-04-02',
+      dailyRecord: null,
+      foodEntries: [
+        {
+          id: 'food-entry-1',
+          createdAt: '2026-04-02T08:00:00.000Z',
+          updatedAt: '2026-04-02T08:00:00.000Z',
+          localDay: '2026-04-02',
+          mealType: 'breakfast',
+          name: 'Mostly-known meal',
+          calories: 320,
+          protein: 24,
+          carbs: 34,
+          fat: 8,
+        },
+      ],
+      nutritionSummary: {
+        calories: 320,
+        protein: 24,
+        fiber: 0,
+        carbs: 34,
+        fat: 8,
+      },
+      plannedMeal: {
+        id: 'planned-meal-1',
+        createdAt: '2026-04-02T08:30:00.000Z',
+        updatedAt: '2026-04-02T08:30:00.000Z',
+        name: 'Greek yogurt bowl',
+        mealType: 'lunch',
+        calories: 310,
+        protein: 20,
+        carbs: 34,
+        fat: 8,
+        sourceName: 'Local catalog',
+      },
+      plannedMealIssue: null,
+      plannedWorkout: null,
+      plannedWorkoutIssue: null,
+      recoveryAdaptation: null,
+      intelligence: {
+        primaryRecommendation: null,
+        fallbackState: null,
+      },
+      planItems: [],
+      events: [],
+      latestJournalEntry: null,
+    };
+
+    expect(createTodayNutritionPulseMetrics(snapshot)).toEqual([
+      { label: 'Protein pace', current: 24, target: 80, projected: 44, tone: 'steady' },
+      { label: 'Fiber pace', current: null, target: 25, projected: null, tone: 'steady' },
+    ]);
+    expect(createPlannedMealProjectionRows(snapshot)).toEqual([
+      'Projected calories: 630',
+      'Projected protein: 44',
+      'Projected carbs: 68',
+      'Projected fat: 16',
+    ]);
+    expect(createTodayNutritionGuidance(snapshot)).toEqual([
+      'The planned meal helps, but protein still looks light for the day.',
+    ]);
   });
 });

--- a/tests/support/component/routeSeeds.ts
+++ b/tests/support/component/routeSeeds.ts
@@ -15,11 +15,14 @@ import { HEALTHKIT_BUNDLE_JSON } from '../fixtures/healthkit-bundle';
 
 export async function seedHealthkitImport() {
   const db = getTestHealthDb();
-  const batch = await previewImport(db, {
+  await previewImport(db, {
     sourceType: 'healthkit-companion',
     rawText: HEALTHKIT_BUNDLE_JSON,
   });
-  await commitImportBatch(db, batch.id);
+  await commitImportBatch(db, {
+    sourceType: 'healthkit-companion',
+    rawText: HEALTHKIT_BUNDLE_JSON,
+  });
 }
 
 export async function seedReviewSnapshotInputs() {


### PR DESCRIPTION
## Summary
- add an external source registry plus provenance metadata across health, nutrition, imports, review, timeline, and today flows
- add symptom and medication suggestion APIs backed by Clinical Tables, RxNorm, and MedlinePlus, with safe external reference links in the UI
- harden import preview/commit dedupe behavior and HealthKit companion export anchors so empty incremental exports do not advance state

## Impact
- users can see where suggestions and nutrition results came from, and when the app is falling back to cache or degraded sources
- import previews and commits now report duplicates consistently before writing artifacts
- iOS companion exports now fail cleanly on empty bundles and only commit anchors after a real bundle is produced

## Validation
- no fresh validation run in this session
- attempted `git commit -m "feat: harden external-source flows and companion exports"` but the repo hook failed on `prettier --check --ignore-unknown` in 34 files and `eslint --fix` was SIGKILL
- user explicitly approved proceeding with PR and merge despite the failed local hooks


---
<!-- grok-describe -->
## 🤖 Grok PR Description

💥 **Type:** `breaking`

> ⚠️ **BREAKING CHANGE** - This PR introduces breaking changes!

### Summary
Harden external source integrations, HealthKit companion exports, and add trusted reference suggestions

### Details
**What changed:**

- **HealthKit Companion (iOS):** Incremental exports now use anchored queries for today's changes since last local sync (vs. last export). Empty bundles throw explicit errors. Anchors commit post-export.
- **External Sources Registry:** Centralized definitions for 15+ sources (USDA, RxNorm, Clinical Tables, etc.) with categories, auth, reliability, production postures.
- **Health Logging:** Add `referenceUrl` to symptoms/templates/doses. New "Suggest symptoms/medications" buttons query Clinical Tables (ICD-10) and RxNorm via APIs, with MedlinePlus links, source metadata (provenance/cache/degradation).
- **Imports:** Preview mode shows adds/duplicates/warnings before commit. Deduping by `sourceRecordId`. Source metadata display. Commit re-parses payload (no batchId).
- **Nutrition:** Search metadata. Recommendations show source posture (adopt/optional), `canPlanDirectly`.
- **Review/Timeline/Today:** Render safe external reference links for meds/symptoms.
- **Server:** New `/api/health/search-*` routes, timeouts, sync upserts for imports.

**Why it matters (health data implications):**

- **Data Integrity:** Anchored incremental exports + deduping prevent duplicates/missing data from companion. Preview protects against bad imports.
- **Trusted References:** Clinical/RxNorm suggestions + MedlinePlus links enable evidence-based logging/review, surfacing sources in UI.
- **Resilience:** Metadata tracks live/cache/degraded states. Fallbacks (e.g., USDA local).
- **Breaking:** Import commit API changed (input vs batchId). Export mode labels updated.

**Tests:** 50+ updated/added for new flows.

### Walkthrough
1. iOS: Export today bundle (incremental), share JSON to /imports.
2. Imports: Preview → review adds/duplicates → commit.
3. Health: Log symptom/med → "Suggest" → apply w/ reference.
4. Review: See reference links section.
5. Nutrition: Search shows metadata/postures.

### Highlights
- Clinical/RxNorm suggestions w/ MedlinePlus
- HealthKit incremental anchored exports
- Import preview + source metadata
- External source registry + resilience


### ⚠️ Needs Testing
This PR may require additional manual testing.

### Changelog Entry
```
breaking: harden external-source flows, companion exports, and add clinical reference suggestions
```

### Related Issues
- 📋 **ICD-10** 
---
*Generated by Grok 4.1 Fast via xAI*
