### PR TITLE
fix: harden server flows and clear ci blockers

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     command:
       'rm -f /tmp/personal-health-cockpit-playwright.sqlite .playwright-mode && ' +
       'touch .playwright-mode && ' +
-      'bun run build && bun run preview -- --host 127.0.0.1 --port 4173',
+      'bun run build && HEALTH_RESET_TOKEN=codex-e2e bun run preview -- --host 127.0.0.1 --port 4173',
     port: 4173,
     reuseExistingServer: false,
   },

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,29 @@
+import type { Handle } from '@sveltejs/kit';
+import { authorizeSessionRequest } from '$lib/server/http/session-guard';
+
+function requestNeedsSession(pathname: string): boolean {
+  if (pathname === '/api/status') {
+    return false;
+  }
+
+  if (pathname.startsWith('/api/')) {
+    return true;
+  }
+
+  if (pathname.startsWith('/_app/')) {
+    return false;
+  }
+
+  return !/\.[a-z0-9]+$/i.test(pathname);
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+  if (requestNeedsSession(event.url.pathname)) {
+    const authResponse = authorizeSessionRequest(event);
+    if (authResponse) {
+      return authResponse;
+    }
+  }
+
+  return await resolve(event);
+};

--- a/src/lib/features/health/components/HealthEventStreamSection.svelte
+++ b/src/lib/features/health/components/HealthEventStreamSection.svelte
@@ -26,7 +26,7 @@
                   class="status-copy"
                   href={toSafeExternalHref(event.referenceUrl) ?? undefined}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="external noreferrer"
                   aria-label={`Learn more about logged medication ${event.title}`}
                 >
                   Learn more

--- a/src/lib/features/health/components/HealthManualLoggingSection.svelte
+++ b/src/lib/features/health/components/HealthManualLoggingSection.svelte
@@ -122,7 +122,7 @@
                 class="status-copy"
                 href={toSafeExternalHref(suggestion.referenceUrl) ?? undefined}
                 target="_blank"
-                rel="noreferrer"
+                rel="external noreferrer"
                 aria-label={`Learn more about ${suggestion.label}`}
               >
                 Learn more

--- a/src/lib/features/health/components/HealthTemplateSection.svelte
+++ b/src/lib/features/health/components/HealthTemplateSection.svelte
@@ -138,7 +138,7 @@
                 class="status-copy"
                 href={toSafeExternalHref(suggestion.referenceUrl) ?? undefined}
                 target="_blank"
-                rel="noreferrer"
+                rel="external noreferrer"
                 aria-label={`Learn more about ${suggestion.label}`}
               >
                 Learn more
@@ -169,7 +169,7 @@
                   class="status-copy"
                   href={toSafeExternalHref(template.referenceUrl) ?? undefined}
                   target="_blank"
-                  rel="noreferrer"
+                  rel="external noreferrer"
                   aria-label={`Learn more about saved ${
                     template.templateType === 'medication' ? 'medication' : 'supplement'
                   } ${template.label}`}

--- a/src/lib/features/imports/intake-state.ts
+++ b/src/lib/features/imports/intake-state.ts
@@ -1,4 +1,4 @@
-import type { ImportBatch, ImportPreviewResult, ImportSourceType } from '$lib/core/domain/types';
+import type { ImportPreviewResult, ImportSourceType } from '$lib/core/domain/types';
 import type { ImportPayloadSummary } from './core';
 
 export type PayloadOrigin = 'manual' | 'file' | 'sample';

--- a/src/lib/features/imports/store.ts
+++ b/src/lib/features/imports/store.ts
@@ -242,8 +242,8 @@ export async function commitImportBatch(
   const resolvedSourceType = analysis?.sourceType ?? input.sourceType;
   const batch = await createImportBatch(store, resolvedSourceType);
   const affectedDays = new Set<string>();
-  let adds = 0;
-  let duplicates = 0;
+  let adds!: number;
+  let duplicates!: number;
 
   if (resolvedSourceType === 'apple-health-xml') {
     const parsed = analysis?.healthEvents ?? parseAppleHealthXml(input.rawText);

--- a/src/lib/features/review/components/ReviewListSection.svelte
+++ b/src/lib/features/review/components/ReviewListSection.svelte
@@ -48,7 +48,7 @@
               <a
                 href={toSafeExternalHref(item.href) ?? undefined}
                 target="_blank"
-                rel="noreferrer"
+                rel="external noreferrer"
                 aria-label={`${item.categoryLabel} reference ${item.label} opens in new tab`}
               >
                 {item.label}

--- a/src/lib/features/timeline/Page.svelte
+++ b/src/lib/features/timeline/Page.svelte
@@ -89,7 +89,7 @@
                     class="timeline-reference-link"
                     href={toSafeExternalHref(item.referenceUrl) ?? undefined}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="external noreferrer"
                     aria-label={`Learn more about timeline event ${item.label}`}
                   >
                     Learn more

--- a/src/lib/features/today/actions.ts
+++ b/src/lib/features/today/actions.ts
@@ -217,12 +217,12 @@ export async function applyTodayRecoveryAction(
 
   if (actionId === 'apply-recovery-meal') {
     const recommendation = adaptation.mealRecommendation;
-    if (!recommendation) {
+    if (!recommendation?.itemId) {
       return false;
     }
 
     const food = (await listFoodCatalogItems(store)).find(
-      (item) => item.name === recommendation.title
+      (item) => item.id === recommendation.itemId
     );
     if (!food) {
       return false;

--- a/src/lib/features/today/components/TodayPlanSurface.svelte
+++ b/src/lib/features/today/components/TodayPlanSurface.svelte
@@ -144,7 +144,7 @@
               class="event-reference-link"
               href={toSafeExternalHref(event.referenceUrl) ?? undefined}
               target="_blank"
-              rel="noreferrer"
+              rel="external noreferrer"
               aria-label={`Learn more about same-day event ${event.label}`}
             >
               Learn more

--- a/src/lib/features/today/intelligence.ts
+++ b/src/lib/features/today/intelligence.ts
@@ -73,6 +73,7 @@ export interface TodayIntelligenceResult {
 }
 
 export interface TodayRecoveryRecommendation {
+  itemId?: string;
   title: string;
   subtitle: string;
   reasons: string[];

--- a/src/lib/features/today/recovery.ts
+++ b/src/lib/features/today/recovery.ts
@@ -137,6 +137,7 @@ function toTodayMealRecommendation(
   }
 
   return {
+    itemId: recommendation.id,
     title: recommendation.title,
     subtitle: recommendation.subtitle,
     reasons: recommendation.reasons,

--- a/src/lib/server/http/control-plane-guard.ts
+++ b/src/lib/server/http/control-plane-guard.ts
@@ -1,0 +1,51 @@
+import { timingSafeEqual } from 'node:crypto';
+
+type ControlPlaneGuardOptions = {
+  envVar: string;
+  headerName: string;
+};
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function safeEqual(left: string | null | undefined, right: string | null | undefined): boolean {
+  if (!left || !right) {
+    return false;
+  }
+
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function readBearerToken(request: Request): string | null {
+  const authorization = request.headers.get('authorization')?.trim();
+  if (!authorization || !authorization.toLowerCase().startsWith('bearer ')) {
+    return null;
+  }
+
+  return authorization.slice('bearer '.length).trim();
+}
+
+export function requireControlPlaneToken(
+  request: Request,
+  options: ControlPlaneGuardOptions
+): Response | null {
+  const expectedToken = readEnv(options.envVar);
+  if (!expectedToken) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const providedToken = request.headers.get(options.headerName)?.trim() ?? readBearerToken(request);
+  if (!safeEqual(providedToken, expectedToken)) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  return null;
+}

--- a/src/lib/server/http/session-guard.ts
+++ b/src/lib/server/http/session-guard.ts
@@ -1,0 +1,158 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type { RequestEvent } from '@sveltejs/kit';
+
+export const HEALTH_SESSION_COOKIE_NAME = 'health_session';
+export const HEALTH_AUTH_TOKEN_HEADER = 'x-health-auth-token';
+
+const BASIC_REALM = 'Personal Health Cockpit';
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
+
+type SessionAuthConfig = {
+  token?: string;
+  username?: string;
+  password?: string;
+  sessionValue: string;
+};
+
+function sessionAuthEnabledForRuntime(): boolean {
+  return process.env.NODE_ENV !== 'test' || process.env.HEALTH_AUTH_TEST_MODE === 'enabled';
+}
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function getSessionAuthConfig(): SessionAuthConfig | null {
+  if (!sessionAuthEnabledForRuntime()) {
+    return null;
+  }
+
+  const token = readEnv('HEALTH_AUTH_TOKEN');
+  const username = readEnv('HEALTH_AUTH_USERNAME');
+  const password = readEnv('HEALTH_AUTH_PASSWORD');
+
+  if (!token && !(username && password)) {
+    return null;
+  }
+
+  return {
+    token,
+    username,
+    password,
+    sessionValue: createHash('sha256')
+      .update([token ?? '', username ?? '', password ?? ''].join('\n'))
+      .digest('hex'),
+  };
+}
+
+function safeEqual(left: string | null | undefined, right: string | null | undefined): boolean {
+  if (!left || !right) {
+    return false;
+  }
+
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function readBearerToken(request: Request): string | null {
+  const explicitHeader = request.headers.get(HEALTH_AUTH_TOKEN_HEADER)?.trim();
+  if (explicitHeader) {
+    return explicitHeader;
+  }
+
+  const authorization = request.headers.get('authorization')?.trim();
+  if (!authorization || !authorization.toLowerCase().startsWith('bearer ')) {
+    return null;
+  }
+
+  return authorization.slice('bearer '.length).trim();
+}
+
+function readBasicAuthorization(request: Request): { username: string; password: string } | null {
+  const authorization = request.headers.get('authorization')?.trim();
+  if (!authorization || !authorization.toLowerCase().startsWith('basic ')) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(authorization.slice('basic '.length).trim(), 'base64').toString(
+      'utf8'
+    );
+    const separatorIndex = decoded.indexOf(':');
+    if (separatorIndex < 0) {
+      return null;
+    }
+
+    return {
+      username: decoded.slice(0, separatorIndex),
+      password: decoded.slice(separatorIndex + 1),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function unauthorizedResponse(config: SessionAuthConfig): Response {
+  const headers = new Headers({
+    'cache-control': 'no-store',
+  });
+
+  if (config.username && config.password) {
+    headers.set('WWW-Authenticate', `Basic realm="${BASIC_REALM}", charset="UTF-8"`);
+  }
+
+  return new Response('Unauthorized', {
+    status: 401,
+    headers,
+  });
+}
+
+function setSessionCookie(event: Pick<RequestEvent, 'cookies'>, sessionValue: string): void {
+  event.cookies.set(HEALTH_SESSION_COOKIE_NAME, sessionValue, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+}
+
+export function authorizeSessionRequest(
+  event: Pick<RequestEvent, 'request' | 'cookies'>
+): Response | null {
+  const config = getSessionAuthConfig();
+  if (!config) {
+    return null;
+  }
+
+  const sessionCookie = event.cookies.get(HEALTH_SESSION_COOKIE_NAME);
+  if (safeEqual(sessionCookie, config.sessionValue)) {
+    return null;
+  }
+
+  const token = readBearerToken(event.request);
+  if (config.token && safeEqual(token, config.token)) {
+    setSessionCookie(event, config.sessionValue);
+    return null;
+  }
+
+  const basicAuth = readBasicAuthorization(event.request);
+  if (
+    config.username &&
+    config.password &&
+    basicAuth &&
+    safeEqual(basicAuth.username, config.username) &&
+    safeEqual(basicAuth.password, config.password)
+  ) {
+    setSessionCookie(event, config.sessionValue);
+    return null;
+  }
+
+  return unauthorizedResponse(config);
+}

--- a/src/lib/server/imports/service.ts
+++ b/src/lib/server/imports/service.ts
@@ -22,11 +22,9 @@ import { drizzleSchema } from '$lib/server/db/drizzle/schema';
 import {
   selectAllMirrorRecords,
   selectMirrorRecordById,
-  selectMirrorRecordsByField,
   selectMirrorRecordsByFieldValues,
   upsertMirrorRecord,
   upsertMirrorRecordSync,
-  upsertMirrorRecords,
   upsertMirrorRecordsSync,
 } from '$lib/server/db/drizzle/mirror';
 import { refreshWeeklyReviewArtifactsForDaysServer } from '$lib/server/review/service';
@@ -67,25 +65,6 @@ function resolveSmartClinicalImport(
     events: imported.events,
     patientIdentity: imported.patientIdentity,
   };
-}
-
-async function stageArtifacts(input: {
-  batchId: string;
-  artifactType: 'healthEvent' | 'journalEntry';
-  records: Array<HealthEvent | JournalEntry>;
-}): Promise<void> {
-  const { db } = getServerDrizzleClient();
-  const timestamp = nowIso();
-
-  const artifacts: ImportArtifact[] = input.records.map((record) => ({
-    ...createRecordMeta(createRecordId('import-artifact'), timestamp),
-    batchId: input.batchId,
-    artifactType: input.artifactType,
-    fingerprint: textFingerprint(JSON.stringify(record)),
-    payload: record as unknown as Record<string, unknown>,
-  }));
-
-  await upsertMirrorRecords(db, 'importArtifacts', drizzleSchema.importArtifacts, artifacts);
 }
 
 function stageArtifactsSync(input: {
@@ -281,8 +260,8 @@ export async function commitImportBatchServer(input: {
   const affectedDays = new Set<string>();
   let healthEvents: HealthEvent[] = [];
   let journalEntries: JournalEntry[] = [];
-  let adds = 0;
-  let duplicates = 0;
+  let adds!: number;
+  let duplicates!: number;
 
   if (resolvedSourceType === 'apple-health-xml') {
     const parsed = analysis?.healthEvents ?? parseAppleHealthXml(input.rawText);

--- a/src/lib/server/planning/store.ts
+++ b/src/lib/server/planning/store.ts
@@ -18,11 +18,16 @@ import { DEFAULT_WEEKLY_PLAN_TITLE } from '$lib/features/planning/service';
 import { getServerDrizzleClient } from '$lib/server/db/drizzle/client';
 import { drizzleSchema } from '$lib/server/db/drizzle/schema';
 import {
+  deserializeMirrorRows,
   selectAllMirrorRecords,
   selectMirrorRecordById,
   selectMirrorRecordsByField,
+  serializeColumnValue,
   upsertMirrorRecord,
+  upsertMirrorRecordSync,
 } from '$lib/server/db/drizzle/mirror';
+
+type MirrorWriteDb = Pick<ReturnType<typeof getServerDrizzleClient>['db'], 'insert' | 'select'>;
 
 function sortByName<T extends { name: string }>(items: T[]): T[] {
   return [...items].sort((left, right) => left.name.localeCompare(right.name));
@@ -30,6 +35,38 @@ function sortByName<T extends { name: string }>(items: T[]): T[] {
 
 function sortByTitle<T extends { title: string }>(items: T[]): T[] {
   return [...items].sort((left, right) => left.title.localeCompare(right.title));
+}
+
+function asTable(table: unknown): Record<string, unknown> {
+  return table as Record<string, unknown>;
+}
+
+function selectMirrorRecordsByFieldSync<T>(
+  db: MirrorWriteDb,
+  table: unknown,
+  field: string,
+  value: unknown
+): T[] {
+  const t = asTable(table);
+  const rows = db
+    .select({ recordJson: t.recordJson as never })
+    .from(table as never)
+    .where(eq(t[field] as never, serializeColumnValue(value)))
+    .all();
+
+  return deserializeMirrorRows<T>(rows as Array<{ recordJson: string }>);
+}
+
+function compareWeeklyPlans(left: WeeklyPlan, right: WeeklyPlan): number {
+  return (
+    right.updatedAt.localeCompare(left.updatedAt) ||
+    right.createdAt.localeCompare(left.createdAt) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function pickCanonicalWeeklyPlan(plans: WeeklyPlan[]): WeeklyPlan | null {
+  return [...plans].sort(compareWeeklyPlans)[0] ?? null;
 }
 
 export async function listFoodCatalogItemsServer(): Promise<FoodCatalogItem[]> {
@@ -74,8 +111,27 @@ export async function listWeeklyPlanSlotsServer(weeklyPlanId: string): Promise<P
 
 export async function listPlanSlotsForDayServer(localDay: string): Promise<PlanSlot[]> {
   const { db } = getServerDrizzleClient();
+  const weeklyPlan = pickCanonicalWeeklyPlan(
+    await selectMirrorRecordsByField<WeeklyPlan>(
+      db,
+      drizzleSchema.weeklyPlans,
+      'weekStart',
+      startOfWeek(localDay)
+    )
+  );
+  if (!weeklyPlan) {
+    return [];
+  }
+
   return sortPlanSlots(
-    await selectMirrorRecordsByField<PlanSlot>(db, drizzleSchema.planSlots, 'localDay', localDay)
+    (
+      await selectMirrorRecordsByField<PlanSlot>(
+        db,
+        drizzleSchema.planSlots,
+        'weeklyPlanId',
+        weeklyPlan.id
+      )
+    ).filter((slot) => slot.localDay === localDay)
   );
 }
 
@@ -106,26 +162,28 @@ export async function listManualGroceriesServer(
 export async function ensureWeeklyPlanServer(anchorDay: string): Promise<WeeklyPlan> {
   const { db } = getServerDrizzleClient();
   const weekStart = startOfWeek(anchorDay);
-  const existing = (
-    await selectMirrorRecordsByField<WeeklyPlan>(
-      db,
-      drizzleSchema.weeklyPlans,
-      'weekStart',
-      weekStart
-    )
-  )[0];
-  if (existing) {
-    return existing;
-  }
+  return db.transaction((tx) => {
+    const existing = pickCanonicalWeeklyPlan(
+      selectMirrorRecordsByFieldSync<WeeklyPlan>(
+        tx,
+        drizzleSchema.weeklyPlans,
+        'weekStart',
+        weekStart
+      )
+    );
+    if (existing) {
+      return existing;
+    }
 
-  const timestamp = new Date().toISOString();
-  const plan: WeeklyPlan = {
-    ...createRecordMeta(createRecordId('weekly-plan'), timestamp),
-    weekStart,
-    title: DEFAULT_WEEKLY_PLAN_TITLE,
-  };
-  await upsertMirrorRecord(db, 'weeklyPlans', drizzleSchema.weeklyPlans, plan);
-  return plan;
+    const timestamp = new Date().toISOString();
+    const plan: WeeklyPlan = {
+      ...createRecordMeta(createRecordId('weekly-plan'), timestamp),
+      weekStart,
+      title: DEFAULT_WEEKLY_PLAN_TITLE,
+    };
+    upsertMirrorRecordSync(tx, 'weeklyPlans', drizzleSchema.weeklyPlans, plan);
+    return plan;
+  });
 }
 
 export async function savePlanSlotServer(input: {
@@ -139,30 +197,30 @@ export async function savePlanSlotServer(input: {
   notes?: string;
 }): Promise<PlanSlot> {
   const { db } = getServerDrizzleClient();
-  const siblings = (
-    await selectMirrorRecordsByField<PlanSlot>(
-      db,
+  return db.transaction((tx) => {
+    const siblings = selectMirrorRecordsByFieldSync<PlanSlot>(
+      tx,
       drizzleSchema.planSlots,
       'weeklyPlanId',
       input.weeklyPlanId
-    )
-  ).filter((slot) => slot.localDay === input.localDay);
-  const timestamp = new Date().toISOString();
-  const slot: PlanSlot = {
-    ...createRecordMeta(createRecordId('plan-slot'), timestamp),
-    weeklyPlanId: input.weeklyPlanId,
-    localDay: input.localDay,
-    slotType: input.slotType,
-    itemType: input.itemType,
-    itemId: input.itemId,
-    mealType: input.slotType === 'meal' ? input.mealType : undefined,
-    title: input.title.trim(),
-    notes: input.notes?.trim() || undefined,
-    status: 'planned',
-    order: siblings.length ? Math.max(...siblings.map((slot) => slot.order)) + 1 : 0,
-  };
-  await upsertMirrorRecord(db, 'planSlots', drizzleSchema.planSlots, slot);
-  return slot;
+    ).filter((slot) => slot.localDay === input.localDay);
+    const timestamp = new Date().toISOString();
+    const slot: PlanSlot = {
+      ...createRecordMeta(createRecordId('plan-slot'), timestamp),
+      weeklyPlanId: input.weeklyPlanId,
+      localDay: input.localDay,
+      slotType: input.slotType,
+      itemType: input.itemType,
+      itemId: input.itemId,
+      mealType: input.slotType === 'meal' ? input.mealType : undefined,
+      title: input.title.trim(),
+      notes: input.notes?.trim() || undefined,
+      status: 'planned',
+      order: siblings.length ? Math.max(...siblings.map((slot) => slot.order)) + 1 : 0,
+    };
+    upsertMirrorRecordSync(tx, 'planSlots', drizzleSchema.planSlots, slot);
+    return slot;
+  });
 }
 
 export async function updatePlanSlotServer(

--- a/src/lib/server/today/page-actions.ts
+++ b/src/lib/server/today/page-actions.ts
@@ -216,7 +216,7 @@ export async function markTodayPlanSlotStatusPageServer(
     return await loadTodayPageServerWithNotice(slot.localDay, `Plan item marked ${status}.`);
   }
 
-  return await loadTodayPageServerWithNotice(state.todayDate, `Plan item marked ${status}.`);
+  return await loadTodayPageServerWithNotice(state.todayDate, 'Plan item no longer exists.');
 }
 
 export async function applyTodayRecoveryActionPageServer(
@@ -232,11 +232,11 @@ export async function applyTodayRecoveryActionPageServer(
 
   if (actionId === 'apply-recovery-meal') {
     const recommendation = adaptation.mealRecommendation;
-    if (!recommendation) {
+    if (!recommendation?.itemId) {
       return await loadTodayPageServerWithNotice(state.todayDate, 'Recovery action unavailable.');
     }
 
-    const food = source.foodCatalogItems.find((item) => item.name === recommendation.title);
+    const food = source.foodCatalogItems.find((item) => item.id === recommendation.itemId);
     if (!food) {
       return await loadTodayPageServerWithNotice(state.todayDate, 'Recovery action unavailable.');
     }

--- a/src/lib/server/today/page-loader.ts
+++ b/src/lib/server/today/page-loader.ts
@@ -9,6 +9,7 @@ import type {
   RecipeCatalogItem,
   WorkoutTemplate,
 } from '$lib/core/domain/types';
+import { sortHealthEventTimestamp } from '$lib/core/shared/health-events';
 import { buildDailyNutritionSummaryFromEntries } from '$lib/features/nutrition/summary';
 import type { TodayPageState } from '$lib/features/today/controller';
 import { createTodayFormFromSnapshot } from '$lib/features/today/model';
@@ -37,13 +38,24 @@ export type TodaySourceData = {
 };
 
 function sortTodayEvents(events: HealthEvent[]): HealthEvent[] {
+  const compareTimestamp = (left: string, right: string): number => {
+    const leftMs = Date.parse(left);
+    const rightMs = Date.parse(right);
+
+    if (Number.isFinite(leftMs) && Number.isFinite(rightMs) && leftMs !== rightMs) {
+      return leftMs - rightMs;
+    }
+
+    return left.localeCompare(right);
+  };
+
   return [...events].sort((left, right) => {
-    const leftTimestamp = left.sourceTimestamp ?? left.createdAt;
-    const rightTimestamp = right.sourceTimestamp ?? right.createdAt;
+    const leftTimestamp = sortHealthEventTimestamp(left);
+    const rightTimestamp = sortHealthEventTimestamp(right);
 
     return (
-      leftTimestamp.localeCompare(rightTimestamp) ||
-      left.createdAt.localeCompare(right.createdAt) ||
+      compareTimestamp(leftTimestamp, rightTimestamp) ||
+      compareTimestamp(left.createdAt, right.createdAt) ||
       left.eventType.localeCompare(right.eventType) ||
       left.id.localeCompare(right.id)
     );

--- a/src/routes/api/db/migrate/+server.ts
+++ b/src/routes/api/db/migrate/+server.ts
@@ -6,6 +6,7 @@ import {
   countMigratedRecords,
   importHealthDbSnapshot,
 } from '$lib/server/db/drizzle/import-snapshot';
+import { requireControlPlaneToken } from '$lib/server/http/control-plane-guard';
 
 const INVALID_MIGRATION_REQUEST_MESSAGE = 'Invalid migration request payload.';
 const SNAPSHOT_KEYS = [
@@ -68,6 +69,14 @@ function parseMigrationRequest(value: unknown): MigrationRequest | null {
 }
 
 export const POST: RequestHandler = async ({ request }) => {
+  const authResponse = requireControlPlaneToken(request, {
+    envVar: 'HEALTH_CONTROL_PLANE_TOKEN',
+    headerName: 'x-health-control-token',
+  });
+  if (authResponse) {
+    return authResponse;
+  }
+
   let body: unknown;
 
   try {

--- a/src/routes/api/test/reset-db/+server.ts
+++ b/src/routes/api/test/reset-db/+server.ts
@@ -4,13 +4,15 @@ import {
   PlaywrightModeRequiredError,
   resetServerDrizzleStorage,
 } from '$lib/server/db/drizzle/client';
-
-const HEALTH_RESET_TOKEN = 'codex-e2e';
+import { requireControlPlaneToken } from '$lib/server/http/control-plane-guard';
 
 export const POST: RequestHandler = async ({ request }) => {
-  const token = request.headers.get('x-health-reset-token');
-  if (token !== HEALTH_RESET_TOKEN) {
-    return new Response('Forbidden', { status: 403 });
+  const authResponse = requireControlPlaneToken(request, {
+    envVar: 'HEALTH_RESET_TOKEN',
+    headerName: 'x-health-reset-token',
+  });
+  if (authResponse) {
+    return authResponse;
   }
 
   try {

--- a/tests/features/unit/db/migrate.route.test.ts
+++ b/tests/features/unit/db/migrate.route.test.ts
@@ -3,6 +3,7 @@ import type { HealthDbSnapshot } from '$lib/core/db/types';
 
 describe('db migrate route', () => {
   afterEach(() => {
+    delete process.env.HEALTH_CONTROL_PLANE_TOKEN;
     vi.doUnmock('$lib/server/db/drizzle/client');
     vi.doUnmock('$lib/server/db/drizzle/import-snapshot');
     vi.restoreAllMocks();
@@ -48,6 +49,7 @@ describe('db migrate route', () => {
   }
 
   it('returns 400 for malformed JSON bodies', async () => {
+    process.env.HEALTH_CONTROL_PLANE_TOKEN = 'control-token';
     const importHealthDbSnapshot = vi.fn(async () => undefined);
     const countMigratedRecords = vi.fn(() => 0);
     const { POST } = await importRoute({ importHealthDbSnapshot, countMigratedRecords });
@@ -55,7 +57,10 @@ describe('db migrate route', () => {
     const response = await POST({
       request: new Request('http://health.test/api/db/migrate', {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: {
+          'content-type': 'application/json',
+          'x-health-control-token': 'control-token',
+        },
         body: '{',
       }),
     } as Parameters<typeof POST>[0]);
@@ -67,6 +72,7 @@ describe('db migrate route', () => {
   });
 
   it('returns 400 for invalid snapshot shapes', async () => {
+    process.env.HEALTH_CONTROL_PLANE_TOKEN = 'control-token';
     const importHealthDbSnapshot = vi.fn(async () => undefined);
     const countMigratedRecords = vi.fn(() => 0);
     const { POST } = await importRoute({ importHealthDbSnapshot, countMigratedRecords });
@@ -74,6 +80,7 @@ describe('db migrate route', () => {
     const response = await POST({
       request: new Request('http://health.test/api/db/migrate', {
         method: 'POST',
+        headers: { 'x-health-control-token': 'control-token' },
         body: JSON.stringify({
           snapshot: {
             ...createSnapshot(),
@@ -90,6 +97,7 @@ describe('db migrate route', () => {
   });
 
   it('ignores legacy plannedMeals data when importing a snapshot', async () => {
+    process.env.HEALTH_CONTROL_PLANE_TOKEN = 'control-token';
     const importHealthDbSnapshot = vi.fn(async () => undefined);
     const countMigratedRecords = vi.fn(() => 0);
     const snapshot = {
@@ -110,6 +118,7 @@ describe('db migrate route', () => {
     const response = await POST({
       request: new Request('http://health.test/api/db/migrate', {
         method: 'POST',
+        headers: { 'x-health-control-token': 'control-token' },
         body: JSON.stringify({ snapshot }),
       }),
     } as Parameters<typeof POST>[0]);
@@ -118,5 +127,24 @@ describe('db migrate route', () => {
     expect(await response.json()).toEqual({ migrated: 0 });
     expect(importHealthDbSnapshot).toHaveBeenCalledWith({ mocked: true }, snapshot);
     expect(countMigratedRecords).toHaveBeenCalledWith(snapshot);
+  });
+
+  it('returns 403 when the control-plane token is missing', async () => {
+    process.env.HEALTH_CONTROL_PLANE_TOKEN = 'control-token';
+    const importHealthDbSnapshot = vi.fn(async () => undefined);
+    const countMigratedRecords = vi.fn(() => 0);
+    const { POST } = await importRoute({ importHealthDbSnapshot, countMigratedRecords });
+
+    const response = await POST({
+      request: new Request('http://health.test/api/db/migrate', {
+        method: 'POST',
+        body: JSON.stringify({ snapshot: createSnapshot() }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('Forbidden');
+    expect(importHealthDbSnapshot).not.toHaveBeenCalled();
+    expect(countMigratedRecords).not.toHaveBeenCalled();
   });
 });

--- a/tests/features/unit/db/reset-db.route.test.ts
+++ b/tests/features/unit/db/reset-db.route.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 describe('reset-db route', () => {
   afterEach(() => {
+    delete process.env.HEALTH_RESET_TOKEN;
     vi.doUnmock('$lib/server/db/drizzle/client');
     vi.restoreAllMocks();
     vi.resetModules();
@@ -25,6 +26,7 @@ describe('reset-db route', () => {
   }
 
   it('returns 403 when the reset token is missing or invalid', async () => {
+    process.env.HEALTH_RESET_TOKEN = 'reset-token';
     const resetServerDrizzleStorage = vi.fn(() => undefined);
     const { POST } = await importRoute({ resetServerDrizzleStorage });
 
@@ -40,6 +42,7 @@ describe('reset-db route', () => {
   });
 
   it('returns 403 when the helper refuses outside playwright mode', async () => {
+    process.env.HEALTH_RESET_TOKEN = 'reset-token';
     const { POST, MockPlaywrightModeRequiredError } = await importRoute({
       resetServerDrizzleStorage: vi.fn(() => {
         throw new MockPlaywrightModeRequiredError();
@@ -49,7 +52,7 @@ describe('reset-db route', () => {
     const response = await POST({
       request: new Request('http://health.test/api/test/reset-db', {
         method: 'POST',
-        headers: { 'x-health-reset-token': 'codex-e2e' },
+        headers: { 'x-health-reset-token': 'reset-token' },
       }),
     } as Parameters<typeof POST>[0]);
 
@@ -58,13 +61,14 @@ describe('reset-db route', () => {
   });
 
   it('returns ok when the helper succeeds', async () => {
+    process.env.HEALTH_RESET_TOKEN = 'reset-token';
     const resetServerDrizzleStorage = vi.fn(() => undefined);
     const { POST } = await importRoute({ resetServerDrizzleStorage });
 
     const response = await POST({
       request: new Request('http://health.test/api/test/reset-db', {
         method: 'POST',
-        headers: { 'x-health-reset-token': 'codex-e2e' },
+        headers: { 'x-health-reset-token': 'reset-token' },
       }),
     } as Parameters<typeof POST>[0]);
 

--- a/tests/features/unit/http/api-session.test.ts
+++ b/tests/features/unit/http/api-session.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handle } from '../../../../src/hooks.server';
+import {
+  authorizeSessionRequest,
+  HEALTH_SESSION_COOKIE_NAME,
+} from '../../../../src/lib/server/http/session-guard';
+
+function createEvent(
+  pathname: string,
+  headers: HeadersInit = {},
+  seedCookies?: Record<string, string>
+) {
+  const cookieJar = new Map(Object.entries(seedCookies ?? {}));
+  const event = {
+    request: new Request(`http://health.test${pathname}`, { headers }),
+    url: new URL(`http://health.test${pathname}`),
+    cookies: {
+      get: (name: string) => cookieJar.get(name),
+      set: (name: string, value: string) => {
+        cookieJar.set(name, value);
+      },
+    },
+  };
+
+  return {
+    event: event as unknown as Parameters<typeof authorizeSessionRequest>[0],
+    cookieJar,
+  };
+}
+
+describe('api session auth', () => {
+  afterEach(() => {
+    delete process.env.HEALTH_AUTH_TOKEN;
+    delete process.env.HEALTH_AUTH_USERNAME;
+    delete process.env.HEALTH_AUTH_PASSWORD;
+    delete process.env.HEALTH_AUTH_TEST_MODE;
+    vi.restoreAllMocks();
+  });
+
+  it('allows requests when session auth is not configured', () => {
+    const { event } = createEvent('/api/today');
+    expect(authorizeSessionRequest(event)).toBeNull();
+  });
+
+  it('accepts basic auth and persists a session cookie', () => {
+    process.env.HEALTH_AUTH_TEST_MODE = 'enabled';
+    process.env.HEALTH_AUTH_USERNAME = 'demo';
+    process.env.HEALTH_AUTH_PASSWORD = 'secret';
+
+    const authorization = `Basic ${Buffer.from('demo:secret').toString('base64')}`;
+    const { event, cookieJar } = createEvent('/api/today', { authorization });
+
+    expect(authorizeSessionRequest(event)).toBeNull();
+    const sessionCookie = cookieJar.get(HEALTH_SESSION_COOKIE_NAME);
+    expect(sessionCookie).toBeTruthy();
+
+    const followUp = createEvent(
+      '/api/today',
+      {},
+      {
+        [HEALTH_SESSION_COOKIE_NAME]: sessionCookie!,
+      }
+    );
+    expect(authorizeSessionRequest(followUp.event)).toBeNull();
+  });
+
+  it('returns 401 for protected requests without credentials', () => {
+    process.env.HEALTH_AUTH_TEST_MODE = 'enabled';
+    process.env.HEALTH_AUTH_USERNAME = 'demo';
+    process.env.HEALTH_AUTH_PASSWORD = 'secret';
+
+    const { event } = createEvent('/api/today');
+    const response = authorizeSessionRequest(event);
+
+    expect(response?.status).toBe(401);
+    expect(response?.headers.get('www-authenticate')).toMatch(/Basic realm=/i);
+  });
+
+  it('keeps the status route public even when auth is configured', async () => {
+    process.env.HEALTH_AUTH_TEST_MODE = 'enabled';
+    process.env.HEALTH_AUTH_USERNAME = 'demo';
+    process.env.HEALTH_AUTH_PASSWORD = 'secret';
+
+    const resolve = vi.fn(async () => new Response('ok'));
+    const { event } = createEvent('/api/status');
+
+    const response = await handle({
+      event: event as Parameters<typeof handle>[0]['event'],
+      resolve,
+    });
+
+    expect(await response.text()).toBe('ok');
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/features/unit/imports/intake-state.test.ts
+++ b/tests/features/unit/imports/intake-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ImportBatch, ImportPreviewResult } from '$lib/core/domain/types';
+import type { ImportPreviewResult } from '$lib/core/domain/types';
 import type { ImportPayloadSummary } from '$lib/features/imports/core';
 import {
   allowsHelperLinks,
@@ -31,14 +31,6 @@ const INVALID_SUMMARY: ImportPayloadSummary = {
   status: 'invalid',
   headline: 'Invalid',
   detail: 'Looks broken.',
-};
-
-const STAGED_BATCH: ImportBatch = {
-  id: 'batch-1',
-  createdAt: '2026-04-02T08:00:00.000Z',
-  updatedAt: '2026-04-02T08:00:00.000Z',
-  sourceType: 'healthkit-companion',
-  status: 'staged',
 };
 
 const PREVIEW_RESULT: ImportPreviewResult = {

--- a/tests/features/unit/today/intelligence.test.ts
+++ b/tests/features/unit/today/intelligence.test.ts
@@ -76,6 +76,7 @@ describe('today intelligence', () => {
             'Workout fallback: downgrade Full body reset to a short walk, mobility reset, or full rest.',
           ],
           mealRecommendation: {
+            itemId: 'food-1',
             title: 'Greek yogurt bowl',
             subtitle: '310 kcal · 24g protein · easy to log',
             reasons: ['It lifts protein pace without adding friction.'],

--- a/tests/features/unit/today/model.test.ts
+++ b/tests/features/unit/today/model.test.ts
@@ -178,6 +178,7 @@ describe('today model', () => {
           'Workout fallback: downgrade Full body reset to a short walk, mobility reset, or full rest.',
         ],
         mealRecommendation: {
+          itemId: 'food-1',
           title: 'Greek yogurt bowl',
           subtitle: 'Saved food · Local catalog · 24g protein',
           reasons: ['Protein-forward and easy to repeat.'],

--- a/tests/features/unit/today/recovery-action-id.test.ts
+++ b/tests/features/unit/today/recovery-action-id.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { useTestHealthDb } from '../../../support/unit/testDb';
+import { logAnxietyEvent, logSymptomEvent } from '$lib/features/health/service';
+import { saveFoodCatalogItem } from '$lib/features/nutrition/store';
+import { ensureWeeklyPlan, savePlanSlot } from '$lib/features/planning/service';
+import { applyTodayRecoveryActionPage, loadTodayPage } from '$lib/features/today/controller';
+
+describe('today recovery action id routing', () => {
+  const getDb = useTestHealthDb();
+
+  it('applies the recommended food by item id when duplicate names exist', async () => {
+    const db = getDb();
+    const weeklyPlan = await ensureWeeklyPlan(db, '2026-04-02');
+    const plannedFood = await saveFoodCatalogItem(db, {
+      name: 'Toast and jam',
+      calories: 260,
+      protein: 6,
+      fiber: 2,
+      carbs: 42,
+      fat: 6,
+    });
+    await saveFoodCatalogItem(db, {
+      name: 'Greek yogurt bowl',
+      calories: 420,
+      protein: 8,
+      fiber: 1,
+      carbs: 50,
+      fat: 18,
+    });
+    const recommendedFood = await saveFoodCatalogItem(db, {
+      name: 'Greek yogurt bowl',
+      calories: 310,
+      protein: 24,
+      fiber: 6,
+      carbs: 34,
+      fat: 8,
+    });
+
+    await db.dailyRecords.put({
+      id: 'daily:2026-04-02',
+      createdAt: '2026-04-02T08:00:00.000Z',
+      updatedAt: '2026-04-02T08:00:00.000Z',
+      date: '2026-04-02',
+      mood: 3,
+      energy: 2,
+      stress: 4,
+      focus: 3,
+      sleepHours: 5.5,
+      sleepQuality: 2,
+      freeformNote: 'Dragging today.',
+    });
+    await logSymptomEvent(db, {
+      localDay: '2026-04-02',
+      symptom: 'Headache',
+      severity: 4,
+    });
+    await logAnxietyEvent(db, {
+      localDay: '2026-04-02',
+      intensity: 7,
+      trigger: 'Cramped schedule',
+      durationMinutes: 25,
+    });
+
+    const plannedSlot = await savePlanSlot(db, {
+      weeklyPlanId: weeklyPlan.id,
+      localDay: '2026-04-02',
+      slotType: 'meal',
+      itemType: 'food',
+      itemId: plannedFood.id,
+      mealType: 'breakfast',
+      title: plannedFood.name,
+    });
+
+    let state = await loadTodayPage(db, '2026-04-02');
+    expect(state.snapshot?.recoveryAdaptation?.mealRecommendation).toMatchObject({
+      itemId: recommendedFood.id,
+      title: 'Greek yogurt bowl',
+    });
+
+    state = await applyTodayRecoveryActionPage(db, state, 'apply-recovery-meal');
+
+    expect(state.saveNotice).toBe('Recovery meal applied.');
+    expect((await db.planSlots.get(plannedSlot.id))?.itemId).toBe(recommendedFood.id);
+  });
+});

--- a/tests/features/unit/today/snapshot.test.ts
+++ b/tests/features/unit/today/snapshot.test.ts
@@ -418,6 +418,7 @@ describe('today snapshot', () => {
       'Workout fallback: downgrade Full body reset to a short walk, mobility reset, or full rest.'
     );
     expect(snapshot.recoveryAdaptation?.mealRecommendation).toMatchObject({
+      itemId: expect.any(String),
       title: 'Greek yogurt bowl',
       actionId: 'apply-recovery-meal',
       actionLabel: 'Swap to recovery meal',


### PR DESCRIPTION
## Summary
- add env-driven session and control-plane guards for server routes
- harden today recovery and planning server flows around stable IDs and transactional ordering
- clear existing lint/format/ci blockers in touched repo files so CI can pass cleanly

## Verification
- bun run format:check
- bun run lint
- bun run test:ci-config
- bun run check:ci
- bun run test:unit
- bun run test:component
- bun run build

## Summary by Sourcery

Harden server-side session and control-plane authentication around key HTTP and database flows, improve determinism of planning/today flows, and update tests and links accordingly.

New Features:
- Introduce environment-driven session authentication with cookie-based persistence for API and page requests via a global SvelteKit handle.
- Add reusable control-plane token guard for protected maintenance routes such as database migration and test reset.

Bug Fixes:
- Make weekly plan selection and daily slot listing deterministic and transactional to avoid race conditions and duplicate plans.
- Ensure today recovery meal actions resolve foods by stable IDs instead of names, and surface a clearer notice when a targeted plan item no longer exists.
- Improve today event sorting to handle non-ISO timestamps more robustly and consistently.
- Require and validate control-plane tokens on db migration and reset routes, returning 403 when missing or invalid.
- Align Playwright E2E reset token usage with the new environment-based reset guard.

Enhancements:
- Remove unused import staging helper in the server imports service and tighten typing around import commit counters.
- Standardize external reference links across health, review, timeline, and today components to use a stricter rel attribute for security/privacy.

Tests:
- Extend and adjust unit tests for db migration, reset-db, and today intelligence flows to cover new auth requirements and recovery recommendation shape.
- Add unit coverage for API session auth behavior, including cookie persistence and public status route exceptions.
- Clean up imports and obsolete fixtures in imports intake-state tests.

---
<!-- grok-describe -->
## 🤖 Grok PR Description

♻️ **Type:** `refactor`

### Summary
Harden server authentication, fix recovery meal selection by item ID, add planning transactions, clear CI blockers

### Details
**Security:** New `hooks.server.ts` enforces session auth (token/basic/cookie) for API/non-static paths except `/api/status`. Control-plane guards protect `/api/db/migrate` and `/api/test/reset-db` with env-token validation using `timingSafeEqual`. Prevents unauthorized health data mutations/resets.

**Reliability:** Planning store now uses DB transactions to canonicalize weekly plans by `weekStart`, avoiding duplicates/races during concurrent access. Today event sorting improved via `sortHealthEventTimestamp` for accurate timelines.

**Health data:** Recovery actions (`apply-recovery-meal`) now match foods by unique `itemId` (added to `TodayRecoveryRecommendation`), fixing swaps with duplicate names—ensures precise nutrition logging tied to catalog items.

**CI/Polish:** Playwright preview uses `HEALTH_RESET_TOKEN`. Minor type fixes, removed dead code, consistent rel attrs on external links for better security/SEO. Comprehensive tests added for guards/recovery.

No breaking changes; auth is opt-in via env vars.

### Walkthrough
1. Deploy `hooks.server.ts` + `session-guard.ts`/`control-plane-guard.ts` for auth on protected paths/endpoints.
2. Update recovery logic (`today/actions.ts`, `intelligence.ts`, `recovery.ts`) to propagate/use `itemId`.
3. Refactor `planning/store.ts` to tx-sync select/upsert canonical `WeeklyPlan` + slots.
4. Secure DB routes (`migrate/+server.ts`, `reset-db/+server.ts`) with guards.
5. Tweak sorting (`page-loader.ts`), links (Sveltes), CI (`playwright.config.ts`), types/tests.

### Highlights
- Protected health DB mutations from unauthorized access
- Fixed recovery meal accuracy with duplicate foods
- Race-safe weekly planning
- CI unblocked, tests hardened



### Changelog Entry
```
fix(server): add session auth hook and control-plane guards for DB endpoints

fix(today): select recovery meals by itemId to handle duplicate names

refactor(planning): use transactions for canonical weekly plan selection

fix(ci): configure playwright reset token

style(links): upgrade external rel attributes to 'external noreferrer'
```
---
*Generated by Grok 4.1 Fast via xAI*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds env-driven session auth for app requests and control-plane token checks for DB admin endpoints. Stabilizes Today recovery and planning with ID-based routing and transactional writes, and unblocks CI.

- **New Features**
  - Session auth middleware via `src/hooks.server.ts` with cookie-based sessions; accepts bearer token (`HEALTH_AUTH_TOKEN` or `Authorization: Bearer`) or basic auth (`HEALTH_AUTH_USERNAME`/`HEALTH_AUTH_PASSWORD`); `/api/status` and static assets stay public.
  - Control-plane guard (`requireControlPlaneToken`) applied to `/api/db/migrate` and `/api/test/reset-db`; tokens via `HEALTH_CONTROL_PLANE_TOKEN` and `HEALTH_RESET_TOKEN` (headers: `x-health-control-token`, `x-health-reset-token`); E2E preview injects reset token.

- **Bug Fixes**
  - Today recovery meal now applies by `itemId` (not title) to handle duplicate names; recommendation includes `itemId`; server/client paths updated and covered by tests.
  - Planning store hardening: pick a canonical weekly plan if duplicates exist, list slots by `weeklyPlanId` then filter by day, and perform plan/slot writes in a single transaction to keep ordering consistent.
  - Today event sorting uses parsed timestamps with stable tie-breakers to avoid mis-ordered events.
  - External links use `rel="external noreferrer"`.
  - Lint/format fixes and test updates to clear CI.

<sup>Written for commit 6a871cfe14be63671e5ee2295b08f0b0cd41f550. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

